### PR TITLE
feat: download Telegram file attachments to group directory

### DIFF
--- a/src/channels/telegram.test.ts
+++ b/src/channels/telegram.test.ts
@@ -24,6 +24,12 @@ vi.mock('../logger.js', () => ({
   },
 }));
 
+// Mock group-folder (used by downloadFile)
+vi.mock('../group-folder.js', () => ({
+  resolveGroupFolderPath: vi.fn((folder: string) => `/tmp/test-groups/${folder}`),
+}));
+
+
 // --- Grammy mock ---
 
 type Handler = (...args: any[]) => any;
@@ -40,6 +46,7 @@ vi.mock('grammy', () => ({
     api = {
       sendMessage: vi.fn().mockResolvedValue(undefined),
       sendChatAction: vi.fn().mockResolvedValue(undefined),
+      getFile: vi.fn().mockResolvedValue({ file_path: 'photos/file_0.jpg' }),
     };
 
     constructor(token: string) {
@@ -69,6 +76,7 @@ vi.mock('grammy', () => ({
   },
 }));
 
+import fs from 'fs';
 import { TelegramChannel, TelegramChannelOpts } from './telegram.js';
 
 // --- Test helpers ---
@@ -178,13 +186,27 @@ async function triggerMediaMessage(
 
 // --- Tests ---
 
+// Helper: flush pending microtasks (for async downloadFile().then() chains)
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+
 describe('TelegramChannel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+
+    // Mock fs operations used by downloadFile
+    vi.spyOn(fs, 'mkdirSync').mockReturnValue(undefined);
+    vi.spyOn(fs, 'writeFileSync').mockReturnValue(undefined);
+
+    // Mock global fetch for file downloads
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(8)),
+    }));
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   // --- Connection lifecycle ---
@@ -541,107 +563,155 @@ describe('TelegramChannel', () => {
   // --- Non-text messages ---
 
   describe('non-text messages', () => {
-    it('stores photo with placeholder', async () => {
-      const opts = createTestOpts();
-      const channel = new TelegramChannel('test-token', opts);
-      await channel.connect();
-
-      const ctx = createMediaCtx({});
-      await triggerMediaMessage('message:photo', ctx);
-
-      expect(opts.onMessage).toHaveBeenCalledWith(
-        'tg:100200300',
-        expect.objectContaining({ content: '[Photo]' }),
-      );
-    });
-
-    it('stores photo with caption', async () => {
-      const opts = createTestOpts();
-      const channel = new TelegramChannel('test-token', opts);
-      await channel.connect();
-
-      const ctx = createMediaCtx({ caption: 'Look at this' });
-      await triggerMediaMessage('message:photo', ctx);
-
-      expect(opts.onMessage).toHaveBeenCalledWith(
-        'tg:100200300',
-        expect.objectContaining({ content: '[Photo] Look at this' }),
-      );
-    });
-
-    it('stores video with placeholder', async () => {
-      const opts = createTestOpts();
-      const channel = new TelegramChannel('test-token', opts);
-      await channel.connect();
-
-      const ctx = createMediaCtx({});
-      await triggerMediaMessage('message:video', ctx);
-
-      expect(opts.onMessage).toHaveBeenCalledWith(
-        'tg:100200300',
-        expect.objectContaining({ content: '[Video]' }),
-      );
-    });
-
-    it('stores voice message with placeholder', async () => {
-      const opts = createTestOpts();
-      const channel = new TelegramChannel('test-token', opts);
-      await channel.connect();
-
-      const ctx = createMediaCtx({});
-      await triggerMediaMessage('message:voice', ctx);
-
-      expect(opts.onMessage).toHaveBeenCalledWith(
-        'tg:100200300',
-        expect.objectContaining({ content: '[Voice message]' }),
-      );
-    });
-
-    it('stores audio with placeholder', async () => {
-      const opts = createTestOpts();
-      const channel = new TelegramChannel('test-token', opts);
-      await channel.connect();
-
-      const ctx = createMediaCtx({});
-      await triggerMediaMessage('message:audio', ctx);
-
-      expect(opts.onMessage).toHaveBeenCalledWith(
-        'tg:100200300',
-        expect.objectContaining({ content: '[Audio]' }),
-      );
-    });
-
-    it('stores document with filename', async () => {
+    it('downloads photo and includes path in content', async () => {
       const opts = createTestOpts();
       const channel = new TelegramChannel('test-token', opts);
       await channel.connect();
 
       const ctx = createMediaCtx({
-        extra: { document: { file_name: 'report.pdf' } },
+        extra: { photo: [{ file_id: 'small_id', width: 90 }, { file_id: 'large_id', width: 800 }] },
       });
-      await triggerMediaMessage('message:document', ctx);
+      await triggerMediaMessage('message:photo', ctx);
+      await flushPromises();
 
+      expect(currentBot().api.getFile).toHaveBeenCalledWith('large_id');
       expect(opts.onMessage).toHaveBeenCalledWith(
         'tg:100200300',
-        expect.objectContaining({ content: '[Document: report.pdf]' }),
+        expect.objectContaining({
+          content: '[Photo] (/workspace/group/attachments/photo_1.jpg)',
+        }),
       );
     });
 
-    it('stores document with fallback name when filename missing', async () => {
+    it('downloads photo with caption', async () => {
       const opts = createTestOpts();
       const channel = new TelegramChannel('test-token', opts);
       await channel.connect();
 
-      const ctx = createMediaCtx({ extra: { document: {} } });
-      await triggerMediaMessage('message:document', ctx);
+      const ctx = createMediaCtx({
+        caption: 'Look at this',
+        extra: { photo: [{ file_id: 'photo_id', width: 800 }] },
+      });
+      await triggerMediaMessage('message:photo', ctx);
+      await flushPromises();
 
       expect(opts.onMessage).toHaveBeenCalledWith(
         'tg:100200300',
-        expect.objectContaining({ content: '[Document: file]' }),
+        expect.objectContaining({
+          content: '[Photo] (/workspace/group/attachments/photo_1.jpg) Look at this',
+        }),
       );
     });
 
-    it('stores sticker with emoji', async () => {
+    it('falls back to placeholder when download fails', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      // Make getFile reject
+      currentBot().api.getFile.mockRejectedValueOnce(new Error('API error'));
+
+      const ctx = createMediaCtx({
+        caption: 'Check this',
+        extra: { photo: [{ file_id: 'bad_id', width: 800 }] },
+      });
+      await triggerMediaMessage('message:photo', ctx);
+      await flushPromises();
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '[Photo] Check this' }),
+      );
+    });
+
+    it('downloads document and includes filename and path', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      currentBot().api.getFile.mockResolvedValueOnce({ file_path: 'documents/file_0.pdf' });
+
+      const ctx = createMediaCtx({
+        extra: { document: { file_name: 'report.pdf', file_id: 'doc_id' } },
+      });
+      await triggerMediaMessage('message:document', ctx);
+      await flushPromises();
+
+      expect(currentBot().api.getFile).toHaveBeenCalledWith('doc_id');
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Document: report.pdf] (/workspace/group/attachments/report.pdf)',
+        }),
+      );
+    });
+
+    it('downloads video', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      currentBot().api.getFile.mockResolvedValueOnce({ file_path: 'videos/file_0.mp4' });
+
+      const ctx = createMediaCtx({
+        extra: { video: { file_id: 'vid_id' } },
+      });
+      await triggerMediaMessage('message:video', ctx);
+      await flushPromises();
+
+      expect(currentBot().api.getFile).toHaveBeenCalledWith('vid_id');
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Video] (/workspace/group/attachments/video_1.mp4)',
+        }),
+      );
+    });
+
+    it('downloads voice message', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      currentBot().api.getFile.mockResolvedValueOnce({ file_path: 'voice/file_0.oga' });
+
+      const ctx = createMediaCtx({
+        extra: { voice: { file_id: 'voice_id' } },
+      });
+      await triggerMediaMessage('message:voice', ctx);
+      await flushPromises();
+
+      expect(currentBot().api.getFile).toHaveBeenCalledWith('voice_id');
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Voice message] (/workspace/group/attachments/voice_1.oga)',
+        }),
+      );
+    });
+
+    it('downloads audio with original filename', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      currentBot().api.getFile.mockResolvedValueOnce({ file_path: 'audio/file_0.mp3' });
+
+      const ctx = createMediaCtx({
+        extra: { audio: { file_id: 'audio_id', file_name: 'song.mp3' } },
+      });
+      await triggerMediaMessage('message:audio', ctx);
+      await flushPromises();
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Audio] (/workspace/group/attachments/song.mp3)',
+        }),
+      );
+    });
+
+    it('stores sticker with emoji (no download)', async () => {
       const opts = createTestOpts();
       const channel = new TelegramChannel('test-token', opts);
       await channel.connect();
@@ -651,13 +721,14 @@ describe('TelegramChannel', () => {
       });
       await triggerMediaMessage('message:sticker', ctx);
 
+      expect(currentBot().api.getFile).not.toHaveBeenCalled();
       expect(opts.onMessage).toHaveBeenCalledWith(
         'tg:100200300',
         expect.objectContaining({ content: '[Sticker 😂]' }),
       );
     });
 
-    it('stores location with placeholder', async () => {
+    it('stores location with placeholder (no download)', async () => {
       const opts = createTestOpts();
       const channel = new TelegramChannel('test-token', opts);
       await channel.connect();
@@ -671,7 +742,7 @@ describe('TelegramChannel', () => {
       );
     });
 
-    it('stores contact with placeholder', async () => {
+    it('stores contact with placeholder (no download)', async () => {
       const opts = createTestOpts();
       const channel = new TelegramChannel('test-token', opts);
       await channel.connect();
@@ -692,8 +763,28 @@ describe('TelegramChannel', () => {
 
       const ctx = createMediaCtx({ chatId: 999999 });
       await triggerMediaMessage('message:photo', ctx);
+      await flushPromises();
 
       expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+
+    it('stores document with fallback name when filename missing', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      currentBot().api.getFile.mockResolvedValueOnce({ file_path: 'documents/file_0.bin' });
+
+      const ctx = createMediaCtx({ extra: { document: { file_id: 'doc_id' } } });
+      await triggerMediaMessage('message:document', ctx);
+      await flushPromises();
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Document: file] (/workspace/group/attachments/file.bin)',
+        }),
+      );
     });
   });
 

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -1,7 +1,11 @@
+import fs from 'fs';
+import path from 'path';
+
 import { Bot } from 'grammy';
 
 import { ASSISTANT_NAME, TRIGGER_PATTERN } from '../config.js';
 import { readEnvFile } from '../env.js';
+import { resolveGroupFolderPath } from '../group-folder.js';
 import { logger } from '../logger.js';
 import { registerChannel, ChannelOpts } from './registry.js';
 import {
@@ -27,6 +31,54 @@ export class TelegramChannel implements Channel {
   constructor(botToken: string, opts: TelegramChannelOpts) {
     this.botToken = botToken;
     this.opts = opts;
+  }
+
+  /**
+   * Download a Telegram file to the group's attachments directory.
+   * Returns the container-relative path (e.g. /workspace/group/attachments/photo_123.jpg)
+   * or null if the download fails.
+   */
+  private async downloadFile(
+    fileId: string,
+    groupFolder: string,
+    filename: string,
+  ): Promise<string | null> {
+    if (!this.bot) return null;
+
+    try {
+      const file = await this.bot.api.getFile(fileId);
+      if (!file.file_path) {
+        logger.warn({ fileId }, 'Telegram getFile returned no file_path');
+        return null;
+      }
+
+      const groupDir = resolveGroupFolderPath(groupFolder);
+      const attachDir = path.join(groupDir, 'attachments');
+      fs.mkdirSync(attachDir, { recursive: true });
+
+      // Sanitize filename and add extension from Telegram's file_path if missing
+      const tgExt = path.extname(file.file_path);
+      const localExt = path.extname(filename);
+      const safeName = filename.replace(/[^a-zA-Z0-9._-]/g, '_');
+      const finalName = localExt ? safeName : `${safeName}${tgExt}`;
+      const destPath = path.join(attachDir, finalName);
+
+      const fileUrl = `https://api.telegram.org/file/bot${this.botToken}/${file.file_path}`;
+      const resp = await fetch(fileUrl);
+      if (!resp.ok) {
+        logger.warn({ fileId, status: resp.status }, 'Telegram file download failed');
+        return null;
+      }
+
+      const buffer = Buffer.from(await resp.arrayBuffer());
+      fs.writeFileSync(destPath, buffer);
+
+      logger.info({ fileId, dest: destPath }, 'Telegram file downloaded');
+      return `/workspace/group/attachments/${finalName}`;
+    } catch (err) {
+      logger.error({ fileId, err }, 'Failed to download Telegram file');
+      return null;
+    }
   }
 
   async connect(): Promise<void> {
@@ -124,8 +176,12 @@ export class TelegramChannel implements Channel {
       );
     });
 
-    // Handle non-text messages with placeholders so the agent knows something was sent
-    const storeNonText = (ctx: any, placeholder: string) => {
+    // Handle non-text messages: download files when possible, fall back to placeholders.
+    const storeMedia = (
+      ctx: any,
+      placeholder: string,
+      opts?: { fileId?: string; filename?: string },
+    ) => {
       const chatJid = `tg:${ctx.chat.id}`;
       const group = this.opts.registeredGroups()[chatJid];
       if (!group) return;
@@ -140,33 +196,77 @@ export class TelegramChannel implements Channel {
 
       const isGroup = ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
       this.opts.onChatMetadata(chatJid, timestamp, undefined, 'telegram', isGroup);
-      this.opts.onMessage(chatJid, {
-        id: ctx.message.message_id.toString(),
-        chat_jid: chatJid,
-        sender: ctx.from?.id?.toString() || '',
-        sender_name: senderName,
-        content: `${placeholder}${caption}`,
-        timestamp,
-        is_from_me: false,
-      });
+
+      const deliver = (content: string) => {
+        this.opts.onMessage(chatJid, {
+          id: ctx.message.message_id.toString(),
+          chat_jid: chatJid,
+          sender: ctx.from?.id?.toString() || '',
+          sender_name: senderName,
+          content,
+          timestamp,
+          is_from_me: false,
+        });
+      };
+
+      // If we have a file_id, attempt to download; deliver asynchronously
+      if (opts?.fileId) {
+        const msgId = ctx.message.message_id.toString();
+        const filename = opts.filename || `${placeholder.replace(/[\[\] ]/g, '').toLowerCase()}_${msgId}`;
+        this.downloadFile(opts.fileId, group.folder, filename).then((filePath) => {
+          if (filePath) {
+            deliver(`${placeholder} (${filePath})${caption}`);
+          } else {
+            deliver(`${placeholder}${caption}`);
+          }
+        });
+        return;
+      }
+
+      deliver(`${placeholder}${caption}`);
     };
 
-    this.bot.on('message:photo', (ctx) => storeNonText(ctx, '[Photo]'));
-    this.bot.on('message:video', (ctx) => storeNonText(ctx, '[Video]'));
-    this.bot.on('message:voice', (ctx) =>
-      storeNonText(ctx, '[Voice message]'),
-    );
-    this.bot.on('message:audio', (ctx) => storeNonText(ctx, '[Audio]'));
+    this.bot.on('message:photo', (ctx) => {
+      // Telegram sends multiple sizes; last is largest
+      const photos = ctx.message.photo;
+      const largest = photos?.[photos.length - 1];
+      storeMedia(ctx, '[Photo]', {
+        fileId: largest?.file_id,
+        filename: `photo_${ctx.message.message_id}`,
+      });
+    });
+    this.bot.on('message:video', (ctx) => {
+      storeMedia(ctx, '[Video]', {
+        fileId: ctx.message.video?.file_id,
+        filename: `video_${ctx.message.message_id}`,
+      });
+    });
+    this.bot.on('message:voice', (ctx) => {
+      storeMedia(ctx, '[Voice message]', {
+        fileId: ctx.message.voice?.file_id,
+        filename: `voice_${ctx.message.message_id}`,
+      });
+    });
+    this.bot.on('message:audio', (ctx) => {
+      const name = ctx.message.audio?.file_name || `audio_${ctx.message.message_id}`;
+      storeMedia(ctx, '[Audio]', {
+        fileId: ctx.message.audio?.file_id,
+        filename: name,
+      });
+    });
     this.bot.on('message:document', (ctx) => {
       const name = ctx.message.document?.file_name || 'file';
-      storeNonText(ctx, `[Document: ${name}]`);
+      storeMedia(ctx, `[Document: ${name}]`, {
+        fileId: ctx.message.document?.file_id,
+        filename: name,
+      });
     });
     this.bot.on('message:sticker', (ctx) => {
       const emoji = ctx.message.sticker?.emoji || '';
-      storeNonText(ctx, `[Sticker ${emoji}]`);
+      storeMedia(ctx, `[Sticker ${emoji}]`);
     });
-    this.bot.on('message:location', (ctx) => storeNonText(ctx, '[Location]'));
-    this.bot.on('message:contact', (ctx) => storeNonText(ctx, '[Contact]'));
+    this.bot.on('message:location', (ctx) => storeMedia(ctx, '[Location]'));
+    this.bot.on('message:contact', (ctx) => storeMedia(ctx, '[Contact]'));
 
     // Handle errors gracefully
     this.bot.catch((err) => {


### PR DESCRIPTION
## Summary

- Download photos, videos, voice messages, audio, and documents via Telegram's `getFile` API
- Save files to the group's `attachments/` directory (`/workspace/group/attachments/` inside the container)
- Fall back to placeholder text if the download fails (graceful degradation)
- Stickers, locations, and contacts remain as text-only placeholders

## How it works

When a user sends a file attachment in Telegram, the channel:
1. Calls `bot.api.getFile(file_id)` to get the file path
2. Downloads the file via `https://api.telegram.org/file/bot<token>/<path>`
3. Saves it to `groups/<name>/attachments/<sanitized_filename>`
4. Delivers the message with the container-relative path: `[Photo] (/workspace/group/attachments/photo_42.jpg)`

If any step fails, the message is delivered with the original placeholder (e.g. `[Photo]`) so the agent still knows something was sent.

## Supported file types

| Type | Downloaded? | Example content |
|------|------------|-----------------|
| Photo | Yes | `[Photo] (/workspace/group/attachments/photo_42.jpg)` |
| Video | Yes | `[Video] (/workspace/group/attachments/video_42.mp4)` |
| Voice | Yes | `[Voice message] (/workspace/group/attachments/voice_42.oga)` |
| Audio | Yes | `[Audio] (/workspace/group/attachments/song.mp3)` |
| Document | Yes | `[Document: report.pdf] (/workspace/group/attachments/report.pdf)` |
| Sticker | No | `[Sticker 😂]` |
| Location | No | `[Location]` |
| Contact | No | `[Contact]` |

## Related

This overlaps with qwibitai/nanoclaw#301, which targets the main repo and is currently marked as pending closure with merge conflicts. This PR targets the channel fork (the correct contribution path per the current architecture) and covers more file types (video, voice, audio in addition to photos and documents).

## Test plan

- [x] All 51 existing + new unit tests pass
- [x] Type-checks cleanly (`tsc --noEmit`)
- [x] Manual test: send photo, document, voice message, and video to a registered Telegram chat — verify files appear in the group's attachments directory and the agent can read them

🤖 Generated with [Claude Code](https://claude.com/claude-code)