### PR TITLE
feat: add Markdown formatting for outbound messages

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -1,4 +1,4 @@
-import { Bot } from 'grammy';
+import { Api, Bot } from 'grammy';
 
 import { ASSISTANT_NAME, TRIGGER_PATTERN } from '../config.js';
 import { readEnvFile } from '../env.js';
@@ -15,6 +15,29 @@ export interface TelegramChannelOpts {
   onMessage: OnInboundMessage;
   onChatMetadata: OnChatMetadata;
   registeredGroups: () => Record<string, RegisteredGroup>;
+}
+
+/**
+ * Send a message with Telegram Markdown parse mode, falling back to plain text.
+ * Claude's output naturally matches Telegram's Markdown v1 format:
+ *   *bold*, _italic_, `code`, ```code blocks```, [links](url)
+ */
+async function sendTelegramMessage(
+  api: { sendMessage: Api['sendMessage'] },
+  chatId: string | number,
+  text: string,
+  options: { message_thread_id?: number } = {},
+): Promise<void> {
+  try {
+    await api.sendMessage(chatId, text, {
+      ...options,
+      parse_mode: 'Markdown',
+    });
+  } catch (err) {
+    // Fallback: send as plain text if Markdown parsing fails
+    logger.debug({ err }, 'Markdown send failed, falling back to plain text');
+    await api.sendMessage(chatId, text, options);
+  }
 }
 
 export class TelegramChannel implements Channel {
@@ -203,10 +226,11 @@ export class TelegramChannel implements Channel {
       // Telegram has a 4096 character limit per message — split if needed
       const MAX_LENGTH = 4096;
       if (text.length <= MAX_LENGTH) {
-        await this.bot.api.sendMessage(numericId, text);
+        await sendTelegramMessage(this.bot.api, numericId, text);
       } else {
         for (let i = 0; i < text.length; i += MAX_LENGTH) {
-          await this.bot.api.sendMessage(
+          await sendTelegramMessage(
+            this.bot.api,
             numericId,
             text.slice(i, i + MAX_LENGTH),
           );


### PR DESCRIPTION
## Summary

- Messages from Claude naturally use Telegram's Markdown v1 format (`*bold*`, `_italic_`, `` `code` ``, ` ```code blocks``` `, `[links](url)`)
- Without `parse_mode`, this formatting renders as raw text with visible asterisks and underscores
- Adds a `sendTelegramMessage` helper that wraps `api.sendMessage` with `parse_mode: 'Markdown'` and falls back to plain text if Telegram rejects the formatting
- Only affects outbound messages in `sendMessage`; does not change `/chatid`, `/ping`, `sendChatAction`, or other API calls

## Changes

- Import `Api` type from grammy
- Add `sendTelegramMessage()` helper with Markdown parse mode and plain-text fallback
- Replace `this.bot.api.sendMessage()` calls in `sendMessage()` with the new helper

## Test plan

- [ ] Send a message containing Markdown formatting (`*bold*`, `_italic_`, `` `code` ``) and verify it renders correctly in Telegram
- [ ] Send a message with malformed Markdown and verify it falls back to plain text
- [ ] Send a message longer than 4096 characters and verify chunked messages also render Markdown
- [ ] Verify `/chatid` and `/ping` commands still work unchanged