### PR TITLE
fix: use https.globalAgent in grammY Bot for sandbox proxy

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -1,3 +1,4 @@
+import https from 'https';
 import { Api, Bot } from 'grammy';
 
 import { ASSISTANT_NAME, TRIGGER_PATTERN } from '../config.js';
@@ -53,7 +54,11 @@ export class TelegramChannel implements Channel {
   }
 
   async connect(): Promise<void> {
-    this.bot = new Bot(this.botToken);
+    this.bot = new Bot(this.botToken, {
+      client: {
+        baseFetchConfig: { agent: https.globalAgent, compress: true },
+      },
+    });
 
     // Command to get chat ID (useful for registration)
     this.bot.command('chatid', (ctx) => {


### PR DESCRIPTION
## Summary
- grammY creates its own `https.Agent` internally, bypassing any global proxy
- In Docker Sandbox, NanoClaw sets `https.globalAgent` to a proxy agent at startup — this change tells grammY to use it instead
- On non-sandbox setups it's a no-op (`https.globalAgent` is just the default agent)

## Test plan
- [x] TypeScript build passes (`npx tsc --noEmit`)
- [ ] Verify Telegram bot connects normally in non-sandbox environment
- [ ] Verify Telegram bot connects through proxy in sandbox environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)