### PR TITLE
fix: only skip /chatid and /ping, let other / messages through

### DIFF
--- a/src/channels/telegram.test.ts
+++ b/src/channels/telegram.test.ts
@@ -295,16 +295,29 @@ describe('TelegramChannel', () => {
       expect(opts.onMessage).not.toHaveBeenCalled();
     });
 
-    it('skips command messages (starting with /)', async () => {
+    it('skips bot commands (/chatid, /ping) but passes other / messages through', async () => {
       const opts = createTestOpts();
       const channel = new TelegramChannel('test-token', opts);
       await channel.connect();
 
-      const ctx = createTextCtx({ text: '/start' });
-      await triggerTextMessage(ctx);
-
+      // Bot commands should be skipped
+      const ctx1 = createTextCtx({ text: '/chatid' });
+      await triggerTextMessage(ctx1);
       expect(opts.onMessage).not.toHaveBeenCalled();
       expect(opts.onChatMetadata).not.toHaveBeenCalled();
+
+      const ctx2 = createTextCtx({ text: '/ping' });
+      await triggerTextMessage(ctx2);
+      expect(opts.onMessage).not.toHaveBeenCalled();
+
+      // Non-bot /commands should flow through
+      const ctx3 = createTextCtx({ text: '/remote-control' });
+      await triggerTextMessage(ctx3);
+      expect(opts.onMessage).toHaveBeenCalledTimes(1);
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: '/remote-control' }),
+      );
     });
 
     it('extracts sender name from first_name', async () => {

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -80,9 +80,15 @@ export class TelegramChannel implements Channel {
       ctx.reply(`${ASSISTANT_NAME} is online.`);
     });
 
+    // Telegram bot commands handled above — skip them in the general handler
+    // so they don't also get stored as messages. All other /commands flow through.
+    const TELEGRAM_BOT_COMMANDS = new Set(['chatid', 'ping']);
+
     this.bot.on('message:text', async (ctx) => {
-      // Skip commands
-      if (ctx.message.text.startsWith('/')) return;
+      if (ctx.message.text.startsWith('/')) {
+        const cmd = ctx.message.text.slice(1).split(/[\s@]/)[0].toLowerCase();
+        if (TELEGRAM_BOT_COMMANDS.has(cmd)) return;
+      }
 
       const chatJid = `tg:${ctx.chat.id}`;
       let content = ctx.message.text;


### PR DESCRIPTION
## Summary
- Changes the Telegram `/` command filter from a whitelist (block all) to a blacklist (only skip known bot commands)
- Previously all messages starting with `/` were silently dropped, preventing NanoClaw-level commands like `/remote-control` from reaching the `onMessage` callback
- Now only `/chatid` and `/ping` (handled by `bot.command()`) are skipped; everything else flows through as a regular message
- Handles Telegram's `/command@botname` group format via `.split(/[\s@]/)`

## Related
- qwibitai/nanoclaw#1072 — adds `/remote-control` command support (requires this change to work in Telegram)

## Test plan
- [x] All 50 Telegram tests pass
- [ ] `/chatid` and `/ping` still work as before
- [ ] `/remote-control` and other `/` messages reach the agent pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)