### PR TITLE
feat: add reply/quoted message context support

### DIFF
--- a/src/channels/telegram.test.ts
+++ b/src/channels/telegram.test.ts
@@ -12,7 +12,34 @@ vi.mock('../env.js', () => ({ readEnvFile: vi.fn(() => ({})) }));
 vi.mock('../config.js', () => ({
   ASSISTANT_NAME: 'Andy',
   TRIGGER_PATTERN: /^@Andy\b/i,
+  DATA_DIR: '/tmp/test-data',
 }));
+
+// Mock fs for media download
+vi.mock('fs', () => ({
+  default: {
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+  },
+}));
+
+// Mock https for downloadUrl
+vi.mock('https', () => {
+  const { EventEmitter } = require('events');
+  return {
+    default: {
+      get: vi.fn((_url: string, cb: (res: any) => void) => {
+        const res = new EventEmitter();
+        setTimeout(() => {
+          res.emit('data', Buffer.from('fake-image-data'));
+          res.emit('end');
+        }, 0);
+        cb(res);
+        return { on: vi.fn().mockReturnThis() };
+      }),
+    },
+  };
+});
 
 // Mock logger
 vi.mock('../logger.js', () => ({
@@ -40,6 +67,7 @@ vi.mock('grammy', () => ({
     api = {
       sendMessage: vi.fn().mockResolvedValue(undefined),
       sendChatAction: vi.fn().mockResolvedValue(undefined),
+      getFile: vi.fn().mockResolvedValue({ file_path: 'photos/test.jpg' }),
     };
 
     constructor(token: string) {
@@ -962,7 +990,8 @@ describe('TelegramChannel', () => {
       expect(opts.onMessage).toHaveBeenCalledWith(
         'tg:100200300',
         expect.objectContaining({
-          content: '[Reply to Bob: We should use TypeScript]\nI agree with this',
+          content:
+            '[Reply to Bob: We should use TypeScript]\nI agree with this',
         }),
       );
     });
@@ -1012,7 +1041,7 @@ describe('TelegramChannel', () => {
       );
     });
 
-    it('describes non-text reply messages', async () => {
+    it('downloads photo from reply and includes path', async () => {
       const opts = createTestOpts();
       const channel = new TelegramChannel('test-token', opts);
       await channel.connect();
@@ -1029,12 +1058,39 @@ describe('TelegramChannel', () => {
       expect(opts.onMessage).toHaveBeenCalledWith(
         'tg:100200300',
         expect.objectContaining({
-          content: '[Reply to Bob: [Photo]]\nNice photo!',
+          content: expect.stringMatching(
+            /\[Reply to Bob: \[Photo\] saved to: \/workspace\/group\/documents\/\d+_reply\.jpg\]\nNice photo!/,
+          ),
         }),
       );
     });
 
-    it('includes reply context in non-text (media) messages', async () => {
+    it('downloads document from reply and includes path with caption', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'Thanks for the file',
+        reply_to_message: {
+          from: { first_name: 'Bob' },
+          document: { file_id: 'doc123', file_name: 'report.pdf' },
+          caption: 'Q1 report',
+        },
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: expect.stringMatching(
+            /\[Reply to Bob: \[Document: report\.pdf\] saved to: \/workspace\/group\/documents\/\d+_reply\.pdf — Q1 report\]\nThanks for the file/,
+          ),
+        }),
+      );
+    });
+
+    it('includes reply context with media download in non-text messages', async () => {
       const opts = createTestOpts();
       const channel = new TelegramChannel('test-token', opts);
       await channel.connect();
@@ -1067,6 +1123,31 @@ describe('TelegramChannel', () => {
         'tg:100200300',
         expect.objectContaining({
           content: 'Just a normal message',
+        }),
+      );
+    });
+
+    it('falls back to text description when media download fails', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      // Make getFile reject to simulate download failure
+      currentBot().api.getFile.mockRejectedValueOnce(new Error('File too old'));
+
+      const ctx = createTextCtx({
+        text: 'What was that?',
+        reply_to_message: {
+          from: { first_name: 'Bob' },
+          photo: [{ file_id: 'expired123' }],
+        },
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Reply to Bob: [Photo]]\nWhat was that?',
         }),
       );
     });

--- a/src/channels/telegram.test.ts
+++ b/src/channels/telegram.test.ts
@@ -102,6 +102,7 @@ function createTextCtx(overrides: {
   messageId?: number;
   date?: number;
   entities?: any[];
+  reply_to_message?: any;
 }) {
   const chatId = overrides.chatId ?? 100200300;
   const chatType = overrides.chatType ?? 'group';
@@ -121,6 +122,7 @@ function createTextCtx(overrides: {
       date: overrides.date ?? Math.floor(Date.now() / 1000),
       message_id: overrides.messageId ?? 1,
       entities: overrides.entities ?? [],
+      reply_to_message: overrides.reply_to_message,
     },
     me: { username: 'andy_ai_bot' },
     reply: vi.fn(),
@@ -136,6 +138,7 @@ function createMediaCtx(overrides: {
   messageId?: number;
   caption?: string;
   extra?: Record<string, any>;
+  reply_to_message?: any;
 }) {
   const chatId = overrides.chatId ?? 100200300;
   return {
@@ -153,6 +156,7 @@ function createMediaCtx(overrides: {
       date: overrides.date ?? Math.floor(Date.now() / 1000),
       message_id: overrides.messageId ?? 1,
       caption: overrides.caption,
+      reply_to_message: overrides.reply_to_message,
       ...(overrides.extra || {}),
     },
     me: { username: 'andy_ai_bot' },
@@ -935,6 +939,136 @@ describe('TelegramChannel', () => {
       await handler(ctx);
 
       expect(ctx.reply).toHaveBeenCalledWith('Andy is online.');
+    });
+  });
+
+  // --- Reply context ---
+
+  describe('reply context', () => {
+    it('prepends reply context for text replies', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'I agree with this',
+        reply_to_message: {
+          from: { first_name: 'Bob', username: 'bob_user' },
+          text: 'We should use TypeScript',
+        },
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Reply to Bob: We should use TypeScript]\nI agree with this',
+        }),
+      );
+    });
+
+    it('falls back to username when first_name missing in reply', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'Yes',
+        reply_to_message: {
+          from: { username: 'bob_user' },
+          text: 'Original message',
+        },
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Reply to bob_user: Original message]\nYes',
+        }),
+      );
+    });
+
+    it('truncates long reply text at 200 characters', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const longText = 'a'.repeat(250);
+      const ctx = createTextCtx({
+        text: 'TL;DR',
+        reply_to_message: {
+          from: { first_name: 'Bob' },
+          text: longText,
+        },
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: `[Reply to Bob: ${'a'.repeat(200)}…]\nTL;DR`,
+        }),
+      );
+    });
+
+    it('describes non-text reply messages', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'Nice photo!',
+        reply_to_message: {
+          from: { first_name: 'Bob' },
+          photo: [{ file_id: 'abc' }],
+        },
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Reply to Bob: [Photo]]\nNice photo!',
+        }),
+      );
+    });
+
+    it('includes reply context in non-text (media) messages', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({
+        reply_to_message: {
+          from: { first_name: 'Bob' },
+          text: 'Send me a photo',
+        },
+      });
+      await triggerMediaMessage('message:photo', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: '[Reply to Bob: Send me a photo]\n[Photo]',
+        }),
+      );
+    });
+
+    it('does not add prefix when there is no reply', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'Just a normal message' });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: 'Just a normal message',
+        }),
+      );
     });
   });
 

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -12,6 +12,38 @@ import {
   RegisteredGroup,
 } from '../types.js';
 
+/**
+ * Describe a Telegram message for reply context.
+ * Returns a short text summary of any message type.
+ */
+function describeMessage(msg: any): string {
+  if (msg.text) return msg.text;
+  if (msg.caption) return `[Media] ${msg.caption}`;
+  if (msg.photo) return '[Photo]';
+  if (msg.video) return '[Video]';
+  if (msg.voice || msg.audio) return '[Audio]';
+  if (msg.document) return `[Document: ${msg.document.file_name || 'file'}]`;
+  if (msg.sticker) return `[Sticker: ${msg.sticker.emoji || ''}]`;
+  if (msg.location) return '[Location]';
+  if (msg.contact) return `[Contact: ${msg.contact.first_name || ''}]`;
+  return '[Message]';
+}
+
+/**
+ * Build a reply-context prefix string from a replied-to message.
+ * Returns empty string if there is no reply.
+ */
+function replyPrefix(msg: any): string {
+  const replyMsg = msg.reply_to_message;
+  if (!replyMsg) return '';
+  const replySender =
+    replyMsg.from?.first_name || replyMsg.from?.username || 'Unknown';
+  const replyText = describeMessage(replyMsg);
+  const truncated =
+    replyText.length > 200 ? replyText.slice(0, 200) + '…' : replyText;
+  return `[Reply to ${replySender}: ${truncated}]\n`;
+}
+
 export interface TelegramChannelOpts {
   onMessage: OnInboundMessage;
   onChatMetadata: OnChatMetadata;
@@ -92,6 +124,13 @@ export class TelegramChannel implements Channel {
 
       const chatJid = `tg:${ctx.chat.id}`;
       let content = ctx.message.text;
+
+      // Include reply context so the agent knows what message is being replied to
+      const replyCtx = replyPrefix(ctx.message);
+      if (replyCtx) {
+        content = replyCtx + content;
+      }
+
       const timestamp = new Date(ctx.message.date * 1000).toISOString();
       const senderName =
         ctx.from?.first_name ||
@@ -178,6 +217,7 @@ export class TelegramChannel implements Channel {
         ctx.from?.id?.toString() ||
         'Unknown';
       const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
+      const replyCtx = replyPrefix(ctx.message);
 
       const isGroup =
         ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
@@ -193,7 +233,7 @@ export class TelegramChannel implements Channel {
         chat_jid: chatJid,
         sender: ctx.from?.id?.toString() || '',
         sender_name: senderName,
-        content: `${placeholder}${caption}`,
+        content: `${replyCtx}${placeholder}${caption}`,
         timestamp,
         is_from_me: false,
       });

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -1,7 +1,9 @@
+import fs from 'fs';
 import https from 'https';
+import path from 'path';
 import { Api, Bot } from 'grammy';
 
-import { ASSISTANT_NAME, TRIGGER_PATTERN } from '../config.js';
+import { ASSISTANT_NAME, DATA_DIR, TRIGGER_PATTERN } from '../config.js';
 import { readEnvFile } from '../env.js';
 import { logger } from '../logger.js';
 import { registerChannel, ChannelOpts } from './registry.js';
@@ -30,14 +32,107 @@ function describeMessage(msg: any): string {
 }
 
 /**
+ * Download a file from a replied-to message and return its saved path.
+ * Returns null if the reply has no downloadable media or download fails.
+ */
+async function downloadReplyMedia(
+  replyMsg: any,
+  botApi: Api,
+  botToken: string,
+  groupFolder: string,
+): Promise<string | null> {
+  try {
+    let fileId: string | undefined;
+    let ext = 'bin';
+
+    if (replyMsg.photo) {
+      const photos = replyMsg.photo;
+      fileId = photos[photos.length - 1]?.file_id;
+      ext = 'jpg';
+    } else if (replyMsg.video) {
+      fileId = replyMsg.video.file_id;
+      ext = 'mp4';
+    } else if (replyMsg.voice) {
+      fileId = replyMsg.voice.file_id;
+      ext = 'ogg';
+    } else if (replyMsg.audio) {
+      fileId = replyMsg.audio.file_id;
+      ext = 'mp3';
+    } else if (replyMsg.document) {
+      fileId = replyMsg.document.file_id;
+      const name = replyMsg.document.file_name || '';
+      const dotIdx = name.lastIndexOf('.');
+      if (dotIdx > 0) ext = name.slice(dotIdx + 1);
+    } else if (replyMsg.sticker && !replyMsg.sticker.is_animated) {
+      fileId = replyMsg.sticker.file_id;
+      ext = 'webp';
+    }
+
+    if (!fileId) return null;
+
+    const fileInfo = await botApi.getFile(fileId);
+    const fileUrl = `https://api.telegram.org/file/bot${botToken}/${fileInfo.file_path}`;
+    const fileBuffer = await downloadUrl(fileUrl);
+
+    const documentsDir = path.join(DATA_DIR, 'documents', groupFolder);
+    fs.mkdirSync(documentsDir, { recursive: true });
+
+    const fileTs = Date.now();
+    const localFileName = `${fileTs}_reply.${ext}`;
+    const localPath = path.join(documentsDir, localFileName);
+    fs.writeFileSync(localPath, fileBuffer);
+
+    logger.info(
+      { groupFolder, localFileName, size: fileBuffer.length },
+      'Downloaded reply media',
+    );
+    return `/workspace/group/documents/${localFileName}`;
+  } catch (err) {
+    logger.error({ err }, 'Failed to download reply media');
+    return null;
+  }
+}
+
+/**
  * Build a reply-context prefix string from a replied-to message.
+ * Downloads media from the reply when possible so the agent can access it.
  * Returns empty string if there is no reply.
  */
-function replyPrefix(msg: any): string {
+async function replyPrefix(
+  msg: any,
+  botApi?: Api,
+  botToken?: string,
+  groupFolder?: string,
+): Promise<string> {
   const replyMsg = msg.reply_to_message;
   if (!replyMsg) return '';
   const replySender =
     replyMsg.from?.first_name || replyMsg.from?.username || 'Unknown';
+
+  // Try to download media from the reply
+  let mediaPath: string | null = null;
+  if (botApi && botToken && groupFolder) {
+    mediaPath = await downloadReplyMedia(
+      replyMsg,
+      botApi,
+      botToken,
+      groupFolder,
+    );
+  }
+
+  if (mediaPath) {
+    const caption = replyMsg.caption ? ` — ${replyMsg.caption}` : '';
+    let typeLabel = '[File]';
+    if (replyMsg.photo) typeLabel = '[Photo]';
+    else if (replyMsg.video) typeLabel = '[Video]';
+    else if (replyMsg.voice) typeLabel = '[Voice]';
+    else if (replyMsg.audio) typeLabel = '[Audio]';
+    else if (replyMsg.document)
+      typeLabel = `[Document: ${replyMsg.document.file_name || 'file'}]`;
+    else if (replyMsg.sticker) typeLabel = '[Sticker]';
+    return `[Reply to ${replySender}: ${typeLabel} saved to: ${mediaPath}${caption}]\n`;
+  }
+
   const replyText = describeMessage(replyMsg);
   const truncated =
     replyText.length > 200 ? replyText.slice(0, 200) + '…' : replyText;
@@ -126,7 +221,13 @@ export class TelegramChannel implements Channel {
       let content = ctx.message.text;
 
       // Include reply context so the agent knows what message is being replied to
-      const replyCtx = replyPrefix(ctx.message);
+      const group = this.opts.registeredGroups()[chatJid];
+      const replyCtx = await replyPrefix(
+        ctx.message,
+        this.bot!.api,
+        this.botToken,
+        group?.folder,
+      );
       if (replyCtx) {
         content = replyCtx + content;
       }
@@ -178,7 +279,6 @@ export class TelegramChannel implements Channel {
       );
 
       // Only deliver full message for registered groups
-      const group = this.opts.registeredGroups()[chatJid];
       if (!group) {
         logger.debug(
           { chatJid, chatName },
@@ -205,7 +305,7 @@ export class TelegramChannel implements Channel {
     });
 
     // Handle non-text messages with placeholders so the agent knows something was sent
-    const storeNonText = (ctx: any, placeholder: string) => {
+    const storeNonText = async (ctx: any, placeholder: string) => {
       const chatJid = `tg:${ctx.chat.id}`;
       const group = this.opts.registeredGroups()[chatJid];
       if (!group) return;
@@ -217,7 +317,12 @@ export class TelegramChannel implements Channel {
         ctx.from?.id?.toString() ||
         'Unknown';
       const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
-      const replyCtx = replyPrefix(ctx.message);
+      const replyCtx = await replyPrefix(
+        ctx.message,
+        this.bot!.api,
+        this.botToken,
+        group.folder,
+      );
 
       const isGroup =
         ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
@@ -330,6 +435,19 @@ export class TelegramChannel implements Channel {
       logger.debug({ jid, err }, 'Failed to send Telegram typing indicator');
     }
   }
+}
+
+function downloadUrl(url: string): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () => resolve(Buffer.concat(chunks)));
+        res.on('error', reject);
+      })
+      .on('error', reject);
+  });
 }
 
 registerChannel('telegram', (opts: ChannelOpts) => {


### PR DESCRIPTION
## Summary

When a user replies to a message in Telegram, the original message content is now included in the context delivered to the agent.

- **Text replies**: Original text is prepended as `[Reply to Name: text]`
- **Media replies**: The media file (photo, video, voice, audio, document, sticker) is **downloaded and saved**, with the path included so the agent can access it: `[Reply to Name: [Photo] saved to: /workspace/group/documents/123_reply.jpg]`
- Falls back to text-only description if media download fails
- Original text truncated at 200 characters
- No prefix added for non-reply messages (zero behavior change)

Addresses qwibitai/nanoclaw#618

## Implementation

Three helper functions:
- `describeMessage(msg)` — short text summary of any message type
- `downloadReplyMedia(msg, api, token, folder)` — downloads media from replied-to message, returns saved path
- `replyPrefix(msg, api?, token?, folder?)` — builds the full reply context prefix, downloading media when possible

Also adds `downloadUrl()` utility for fetching files from Telegram API.

## Tests

8 new test cases (58 total, all passing):
- Reply to text message
- Fallback to username when first_name missing
- Truncation of long reply text (>200 chars)
- Photo download from reply with path in content
- Document download from reply with caption
- Reply context in media messages
- No prefix for non-reply messages
- Fallback to text description when download fails

## Test plan

- [x] Reply to text — agent sees `[Reply to Name: text]` prefix
- [x] Reply to photo — agent sees `[Reply to Name: [Photo] saved to: path]` with downloaded file
- [x] Reply to document — agent sees path and caption
- [x] Non-reply message — no prefix, unchanged behavior
- [x] Expired/unavailable media — graceful fallback to `[Photo]` description