### PR TITLE
feat: add bidirectional photo and document support

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -1,9 +1,11 @@
 import https from 'https';
-import { Api, Bot } from 'grammy';
+import path from 'path';
+import { Api, Bot, InputFile } from 'grammy';
 
-import { ASSISTANT_NAME, TRIGGER_PATTERN } from '../config.js';
+import { ASSISTANT_NAME, GROUPS_DIR, TRIGGER_PATTERN } from '../config.js';
 import { readEnvFile } from '../env.js';
 import { logger } from '../logger.js';
+import { parseMediaReferences, saveTelegramDocument, saveTelegramPhoto } from '../telegram-media.js';
 import { registerChannel, ChannelOpts } from './registry.js';
 import {
   Channel,
@@ -199,13 +201,93 @@ export class TelegramChannel implements Channel {
       });
     };
 
-    this.bot.on('message:photo', (ctx) => storeNonText(ctx, '[Photo]'));
+    this.bot.on('message:photo', async (ctx) => {
+      const chatJid = `tg:${ctx.chat.id}`;
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) return;
+
+      const timestamp = new Date(ctx.message.date * 1000).toISOString();
+      const senderName =
+        ctx.from?.first_name ||
+        ctx.from?.username ||
+        ctx.from?.id?.toString() ||
+        'Unknown';
+      const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
+
+      let content: string;
+      try {
+        const groupDir = path.join(GROUPS_DIR, group.folder);
+        const relPath = await saveTelegramPhoto(
+          this.botToken,
+          ctx.message.photo,
+          groupDir,
+          ctx.message.message_id.toString(),
+        );
+        content = `[Photo: ${relPath}]${caption}`;
+      } catch (err) {
+        logger.warn({ err, chatJid }, 'Failed to download photo, using placeholder');
+        content = `[Photo]${caption}`;
+      }
+
+      const isGroup =
+        ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+      this.opts.onChatMetadata(chatJid, timestamp, undefined, 'telegram', isGroup);
+      this.opts.onMessage(chatJid, {
+        id: ctx.message.message_id.toString(),
+        chat_jid: chatJid,
+        sender: ctx.from?.id?.toString() || '',
+        sender_name: senderName,
+        content,
+        timestamp,
+        is_from_me: false,
+      });
+    });
+
     this.bot.on('message:video', (ctx) => storeNonText(ctx, '[Video]'));
     this.bot.on('message:voice', (ctx) => storeNonText(ctx, '[Voice message]'));
     this.bot.on('message:audio', (ctx) => storeNonText(ctx, '[Audio]'));
-    this.bot.on('message:document', (ctx) => {
-      const name = ctx.message.document?.file_name || 'file';
-      storeNonText(ctx, `[Document: ${name}]`);
+
+    this.bot.on('message:document', async (ctx) => {
+      const chatJid = `tg:${ctx.chat.id}`;
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) return;
+
+      const timestamp = new Date(ctx.message.date * 1000).toISOString();
+      const senderName =
+        ctx.from?.first_name ||
+        ctx.from?.username ||
+        ctx.from?.id?.toString() ||
+        'Unknown';
+      const caption = ctx.message.caption ? ` ${ctx.message.caption}` : '';
+      const fileName = ctx.message.document?.file_name || 'file';
+
+      let content: string;
+      try {
+        const groupDir = path.join(GROUPS_DIR, group.folder);
+        const relPath = await saveTelegramDocument(
+          this.botToken,
+          ctx.message.document!,
+          groupDir,
+          ctx.message.message_id.toString(),
+        );
+        content = `[Document: ${relPath}]${caption}`;
+      } catch (err) {
+        logger.warn({ err, chatJid }, 'Failed to download document, using placeholder');
+        content = `[Document: ${fileName}]${caption}`;
+      }
+
+      const isGroup =
+        ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+      this.opts.onChatMetadata(chatJid, timestamp, undefined, 'telegram', isGroup);
+      this.opts.onMessage(chatJid, {
+        id: ctx.message.message_id.toString(),
+        chat_jid: chatJid,
+        sender: ctx.from?.id?.toString() || '',
+        sender_name: senderName,
+        content,
+        timestamp,
+        is_from_me: false,
+      });
     });
     this.bot.on('message:sticker', (ctx) => {
       const emoji = ctx.message.sticker?.emoji || '';
@@ -246,20 +328,49 @@ export class TelegramChannel implements Channel {
     try {
       const numericId = jid.replace(/^tg:/, '');
 
-      // Telegram has a 4096 character limit per message — split if needed
-      const MAX_LENGTH = 4096;
-      if (text.length <= MAX_LENGTH) {
-        await sendTelegramMessage(this.bot.api, numericId, text);
-      } else {
-        for (let i = 0; i < text.length; i += MAX_LENGTH) {
-          await sendTelegramMessage(
-            this.bot.api,
-            numericId,
-            text.slice(i, i + MAX_LENGTH),
-          );
+      // Check for media references in agent output
+      const { refs, plainText } = parseMediaReferences(text);
+
+      if (refs.length > 0) {
+        const group = this.opts.registeredGroups()[jid];
+        if (group) {
+          const groupDir = path.join(GROUPS_DIR, group.folder);
+          for (const ref of refs) {
+            const filePath = path.resolve(groupDir, ref.relativePath);
+            if (!filePath.startsWith(groupDir)) {
+              logger.warn({ jid, ref }, 'Media path escapes group directory, skipping');
+              continue;
+            }
+            try {
+              if (ref.type === 'photo') {
+                await this.bot.api.sendPhoto(numericId, new InputFile(filePath));
+              } else {
+                await this.bot.api.sendDocument(numericId, new InputFile(filePath));
+              }
+            } catch (err) {
+              logger.warn({ jid, ref, err }, 'Failed to send media, sending as text');
+              await sendTelegramMessage(this.bot.api, numericId, `[${ref.type}: ${ref.relativePath}]`);
+            }
+          }
         }
       }
-      logger.info({ jid, length: text.length }, 'Telegram message sent');
+
+      // Send remaining text (if any)
+      if (plainText) {
+        const MAX_LENGTH = 4096;
+        if (plainText.length <= MAX_LENGTH) {
+          await sendTelegramMessage(this.bot.api, numericId, plainText);
+        } else {
+          for (let i = 0; i < plainText.length; i += MAX_LENGTH) {
+            await sendTelegramMessage(
+              this.bot.api,
+              numericId,
+              plainText.slice(i, i + MAX_LENGTH),
+            );
+          }
+        }
+      }
+      logger.info({ jid, length: text.length, mediaCount: refs.length }, 'Telegram message sent');
     } catch (err) {
       logger.error({ jid, err }, 'Failed to send Telegram message');
     }

--- a/src/telegram-media.test.ts
+++ b/src/telegram-media.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock logger
+vi.mock('./logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock fs
+vi.mock('fs', () => ({
+  default: {
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
+  },
+}));
+
+// Mock https — configured per test
+const mockHttpsGet = vi.fn();
+vi.mock('https', () => ({
+  default: {
+    get: (...args: unknown[]) => mockHttpsGet(...args),
+  },
+}));
+
+import {
+  pickBestPhotoSize,
+  sanitizeFilename,
+  ensureAttachmentsDir,
+  parseMediaReferences,
+} from './telegram-media.js';
+import fs from 'fs';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// --- pickBestPhotoSize ---
+
+describe('pickBestPhotoSize', () => {
+  it('picks the largest size within dimension limit', () => {
+    const sizes = [
+      { file_id: 'a', file_unique_id: 'ua', width: 90, height: 90 },
+      { file_id: 'b', file_unique_id: 'ub', width: 320, height: 320 },
+      { file_id: 'c', file_unique_id: 'uc', width: 800, height: 800 },
+      { file_id: 'd', file_unique_id: 'ud', width: 1280, height: 1280 },
+      { file_id: 'e', file_unique_id: 'ue', width: 2560, height: 2560 },
+    ];
+
+    const result = pickBestPhotoSize(sizes);
+    expect(result.file_id).toBe('d'); // 1280 <= 1568
+  });
+
+  it('returns smallest when all exceed limit', () => {
+    const sizes = [
+      { file_id: 'a', file_unique_id: 'ua', width: 2000, height: 2000 },
+      { file_id: 'b', file_unique_id: 'ub', width: 3000, height: 3000 },
+    ];
+
+    const result = pickBestPhotoSize(sizes);
+    expect(result.file_id).toBe('a'); // smallest of the oversized
+  });
+
+  it('handles single photo size', () => {
+    const sizes = [
+      { file_id: 'x', file_unique_id: 'ux', width: 640, height: 480 },
+    ];
+
+    const result = pickBestPhotoSize(sizes);
+    expect(result.file_id).toBe('x');
+  });
+
+  it('throws on empty array', () => {
+    expect(() => pickBestPhotoSize([])).toThrow('No photo sizes available');
+  });
+
+  it('handles non-square photos correctly', () => {
+    const sizes = [
+      { file_id: 'a', file_unique_id: 'ua', width: 1568, height: 800 },
+      { file_id: 'b', file_unique_id: 'ub', width: 1600, height: 800 },
+    ];
+
+    const result = pickBestPhotoSize(sizes);
+    expect(result.file_id).toBe('a'); // 1568 <= 1568, 800 <= 1568
+  });
+});
+
+// --- sanitizeFilename ---
+
+describe('sanitizeFilename', () => {
+  it('prefixes with message ID', () => {
+    expect(sanitizeFilename('report.pdf', '42')).toBe('42-report.pdf');
+  });
+
+  it('returns fallback for undefined name', () => {
+    expect(sanitizeFilename(undefined, '42')).toBe('doc-42');
+  });
+
+  it('strips directory traversal', () => {
+    expect(sanitizeFilename('../../../etc/passwd', '42')).toBe('42-passwd');
+  });
+
+  it('strips null bytes', () => {
+    expect(sanitizeFilename('file\0.txt', '42')).toBe('42-file.txt');
+  });
+
+  it('truncates long filenames preserving extension', () => {
+    const longName = 'a'.repeat(250) + '.pdf';
+    const result = sanitizeFilename(longName, '42');
+    expect(result.length).toBeLessThanOrEqual(210); // 42- prefix + 200 limit
+    expect(result).toMatch(/\.pdf$/);
+  });
+});
+
+// --- ensureAttachmentsDir ---
+
+describe('ensureAttachmentsDir', () => {
+  it('creates attachments subdirectory', () => {
+    ensureAttachmentsDir('/groups/main');
+    expect(fs.mkdirSync).toHaveBeenCalledWith('/groups/main/attachments', {
+      recursive: true,
+    });
+  });
+
+  it('returns the attachments path', () => {
+    const result = ensureAttachmentsDir('/groups/main');
+    expect(result).toBe('/groups/main/attachments');
+  });
+});
+
+// --- parseMediaReferences ---
+
+describe('parseMediaReferences', () => {
+  it('extracts photo references', () => {
+    const text = 'Here is the image:\n[Photo: attachments/photo-42.jpg]\nWhat do you think?';
+    const { refs, plainText } = parseMediaReferences(text);
+    expect(refs).toEqual([{ type: 'photo', relativePath: 'attachments/photo-42.jpg' }]);
+    expect(plainText).toBe('Here is the image:\nWhat do you think?');
+  });
+
+  it('extracts document references', () => {
+    const text = '[Document: attachments/report.pdf]\nSee the summary above.';
+    const { refs, plainText } = parseMediaReferences(text);
+    expect(refs).toEqual([{ type: 'document', relativePath: 'attachments/report.pdf' }]);
+    expect(plainText).toBe('See the summary above.');
+  });
+
+  it('extracts multiple mixed references', () => {
+    const text = '[Photo: attachments/a.jpg]\n[Document: attachments/b.pdf]\nDone.';
+    const { refs, plainText } = parseMediaReferences(text);
+    expect(refs).toHaveLength(2);
+    expect(refs[0].type).toBe('photo');
+    expect(refs[1].type).toBe('document');
+    expect(plainText).toBe('Done.');
+  });
+
+  it('returns empty refs for plain text', () => {
+    const text = 'No media here.';
+    const { refs, plainText } = parseMediaReferences(text);
+    expect(refs).toHaveLength(0);
+    expect(plainText).toBe('No media here.');
+  });
+});

--- a/src/telegram-media.ts
+++ b/src/telegram-media.ts
@@ -1,0 +1,248 @@
+/**
+ * Telegram media download and processing utilities.
+ * Downloads photos and documents from Telegram Bot API and saves them
+ * to the group's attachments directory for agent access.
+ */
+import fs from 'fs';
+import https from 'https';
+import path from 'path';
+
+import { logger } from './logger.js';
+
+interface PhotoSize {
+  file_id: string;
+  file_unique_id: string;
+  width: number;
+  height: number;
+  file_size?: number;
+}
+
+interface TelegramDocument {
+  file_id: string;
+  file_unique_id: string;
+  file_name?: string;
+  mime_type?: string;
+  file_size?: number;
+}
+
+/** Maximum dimension for photos sent to Claude's vision API. */
+const MAX_PHOTO_DIMENSION = 1568;
+
+/** Maximum file size for Telegram Bot API getFile (20MB). */
+const MAX_TELEGRAM_FILE_SIZE = 20 * 1024 * 1024;
+
+/**
+ * Download a file from Telegram Bot API.
+ * Uses getFile to get the file path, then fetches the binary content.
+ */
+export async function downloadTelegramFile(
+  botToken: string,
+  fileId: string,
+): Promise<Buffer> {
+  // Step 1: Get file path from Telegram
+  const fileInfo = await fetchJson(
+    `https://api.telegram.org/bot${botToken}/getFile?file_id=${fileId}`,
+  );
+  if (!fileInfo.ok || !fileInfo.result?.file_path) {
+    throw new Error(
+      `Telegram getFile failed: ${fileInfo.description || 'unknown error'}`,
+    );
+  }
+
+  // Step 2: Download file content
+  const fileUrl = `https://api.telegram.org/file/bot${botToken}/${fileInfo.result.file_path}`;
+  return fetchBuffer(fileUrl);
+}
+
+/**
+ * Pick the best photo size from Telegram's PhotoSize array.
+ * Returns the largest size where both dimensions are <= MAX_PHOTO_DIMENSION.
+ * If all sizes exceed the limit, returns the smallest available.
+ */
+export function pickBestPhotoSize(photoSizes: PhotoSize[]): PhotoSize {
+  if (photoSizes.length === 0) {
+    throw new Error('No photo sizes available');
+  }
+
+  // Sort by area (largest first)
+  const sorted = [...photoSizes].sort(
+    (a, b) => b.width * b.height - a.width * a.height,
+  );
+
+  // Find largest that fits within Claude's recommended dimensions
+  const fitting = sorted.find(
+    (p) => p.width <= MAX_PHOTO_DIMENSION && p.height <= MAX_PHOTO_DIMENSION,
+  );
+
+  // If none fit, use the smallest available (Telegram always provides a small thumbnail)
+  return fitting || sorted[sorted.length - 1];
+}
+
+/**
+ * Download a Telegram photo and save it to the group's attachments directory.
+ * Returns the relative path (e.g. "attachments/photo-42.jpg").
+ */
+export async function saveTelegramPhoto(
+  botToken: string,
+  photoSizes: PhotoSize[],
+  groupDir: string,
+  messageId: string,
+): Promise<string> {
+  const bestSize = pickBestPhotoSize(photoSizes);
+
+  // Check file size if available (skip if too large for Telegram API)
+  if (bestSize.file_size && bestSize.file_size > MAX_TELEGRAM_FILE_SIZE) {
+    throw new Error(
+      `Photo too large for Telegram API: ${bestSize.file_size} bytes`,
+    );
+  }
+
+  const buffer = await downloadTelegramFile(botToken, bestSize.file_id);
+  const filename = `photo-${messageId}.jpg`;
+  const attachDir = ensureAttachmentsDir(groupDir);
+  const filePath = path.join(attachDir, filename);
+
+  fs.writeFileSync(filePath, buffer);
+  logger.debug(
+    { messageId, size: buffer.length, width: bestSize.width, height: bestSize.height },
+    'Telegram photo saved',
+  );
+
+  return `attachments/${filename}`;
+}
+
+/**
+ * Download a Telegram document and save it to the group's attachments directory.
+ * Returns the relative path (e.g. "attachments/report.pdf").
+ */
+export async function saveTelegramDocument(
+  botToken: string,
+  document: TelegramDocument,
+  groupDir: string,
+  messageId: string,
+): Promise<string> {
+  // Check file size if available
+  if (document.file_size && document.file_size > MAX_TELEGRAM_FILE_SIZE) {
+    throw new Error(
+      `Document too large for Telegram API: ${document.file_size} bytes`,
+    );
+  }
+
+  const buffer = await downloadTelegramFile(botToken, document.file_id);
+  const filename = sanitizeFilename(document.file_name, messageId);
+  const attachDir = ensureAttachmentsDir(groupDir);
+  const filePath = path.join(attachDir, filename);
+
+  fs.writeFileSync(filePath, buffer);
+  logger.debug(
+    { messageId, filename, size: buffer.length, mimeType: document.mime_type },
+    'Telegram document saved',
+  );
+
+  return `attachments/${filename}`;
+}
+
+/**
+ * Sanitize a filename to prevent path traversal and ensure uniqueness.
+ */
+export function sanitizeFilename(
+  originalName: string | undefined,
+  messageId: string,
+): string {
+  if (!originalName) return `doc-${messageId}`;
+
+  // Strip directory components and null bytes
+  const base = path.basename(originalName).replace(/\0/g, '');
+
+  // Limit length
+  if (base.length > 200) {
+    const ext = path.extname(base);
+    return `${base.slice(0, 200 - ext.length)}${ext}`;
+  }
+
+  // Prefix with message ID to avoid collisions
+  return `${messageId}-${base}`;
+}
+
+export interface MediaRef {
+  type: 'photo' | 'document';
+  relativePath: string;
+}
+
+/**
+ * Extract media references from agent output text.
+ * Returns the references and the text with references removed.
+ */
+export function parseMediaReferences(text: string): { refs: MediaRef[]; plainText: string } {
+  const refs: MediaRef[] = [];
+  const cleaned = text.replace(
+    /\[(Photo|Document): (attachments\/[^\]]+)\]\n?/g,
+    (_match, type, relPath) => {
+      refs.push({
+        type: type.toLowerCase() as 'photo' | 'document',
+        relativePath: relPath,
+      });
+      return '';
+    },
+  );
+  return { refs, plainText: cleaned.trim() };
+}
+
+/**
+ * Ensure the attachments directory exists in the group folder.
+ * Returns the absolute path to the attachments directory.
+ */
+export function ensureAttachmentsDir(groupDir: string): string {
+  const attachDir = path.join(groupDir, 'attachments');
+  fs.mkdirSync(attachDir, { recursive: true });
+  return attachDir;
+}
+
+// --- HTTP helpers ---
+
+/** HTTP request timeout in milliseconds (30 seconds). */
+const HTTP_TIMEOUT_MS = 30_000;
+
+function fetchJson(url: string): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const req = https
+      .get(url, (res) => {
+        let data = '';
+        res.on('data', (chunk) => (data += chunk));
+        res.on('end', () => {
+          try {
+            resolve(JSON.parse(data));
+          } catch {
+            reject(new Error(`Invalid JSON from Telegram API`));
+          }
+        });
+      })
+      .on('error', reject);
+    req.setTimeout(HTTP_TIMEOUT_MS, () => {
+      req.destroy(new Error(`Request timed out after ${HTTP_TIMEOUT_MS}ms`));
+    });
+  });
+}
+
+function fetchBuffer(url: string): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const req = https
+      .get(url, (res) => {
+        if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          fetchBuffer(res.headers.location).then(resolve, reject);
+          return;
+        }
+        if (res.statusCode && res.statusCode >= 400) {
+          reject(new Error(`HTTP ${res.statusCode} from Telegram file API`));
+          return;
+        }
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () => resolve(Buffer.concat(chunks)));
+      })
+      .on('error', reject);
+    req.setTimeout(HTTP_TIMEOUT_MS, () => {
+      req.destroy(new Error(`Request timed out after ${HTTP_TIMEOUT_MS}ms`));
+    });
+  });
+}


### PR DESCRIPTION
## Type of Change

- [x] **Feature** - new functionality

## Summary

- Download Telegram photos and documents to `groups/{folder}/attachments/` so the agent can view images (Claude vision via Read tool) and read documents
- Outbound: agent output containing `[Photo: path]` or `[Document: path]` is sent as native Telegram media via `InputFile`
- Graceful fallback to text placeholders on download error

## Details

**Inbound (user → agent):**
- Photos: picks best size from Telegram's `PhotoSize[]` (largest ≤ 1568px, Claude's recommended max), downloads via Bot API, saves as JPEG
- Documents: downloads and saves with sanitized filename (path traversal protection)
- 30-second HTTP timeout prevents blocking on slow/failed downloads
- On error, falls back to `[Photo]` / `[Document: name]` placeholder — no message lost

**Outbound (agent → user):**
- `sendMessage` parses `[Photo: attachments/...]` and `[Document: attachments/...]` references from agent output
- Sends matched files as native Telegram photos/documents via `InputFile`
- Path traversal guard: resolved path must stay within group directory
- Remaining text sent as regular message (with existing Markdown formatting)
- Falls back to text if file send fails

**New file: `src/telegram-media.ts`** — self-contained module with download, save, parse, and sanitize utilities. No new npm dependencies (uses Node built-in `https`).

## Test plan

- [x] 16 unit tests (photo size selection, filename sanitization, media reference parsing, attachments dir)
- [x] All 267 existing tests pass
- [x] Build clean
- [x] End-to-end verified: photo sent → agent described image content
- [x] End-to-end verified: PDF sent → agent read and summarized document
- [x] End-to-end verified: agent downloaded image → sent back as Telegram photo
- [x] Error case: download timeout → fell back to placeholder gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)