### PR TITLE
fix: skip messages from the bot itself to prevent loops

### DIFF
--- a/src/channels/telegram.test.ts
+++ b/src/channels/telegram.test.ts
@@ -99,6 +99,7 @@ function createTextCtx(overrides: {
   fromId?: number;
   firstName?: string;
   username?: string;
+  isBot?: boolean;
   messageId?: number;
   date?: number;
   entities?: any[];
@@ -113,6 +114,7 @@ function createTextCtx(overrides: {
     },
     from: {
       id: overrides.fromId ?? 99001,
+      is_bot: overrides.isBot ?? false,
       first_name: overrides.firstName ?? 'Alice',
       username: overrides.username ?? 'alice_user',
     },
@@ -132,6 +134,7 @@ function createMediaCtx(overrides: {
   chatType?: string;
   fromId?: number;
   firstName?: string;
+  isBot?: boolean;
   date?: number;
   messageId?: number;
   caption?: string;
@@ -146,6 +149,7 @@ function createMediaCtx(overrides: {
     },
     from: {
       id: overrides.fromId ?? 99001,
+      is_bot: overrides.isBot ?? false,
       first_name: overrides.firstName ?? 'Alice',
       username: 'alice_user',
     },
@@ -431,6 +435,65 @@ describe('TelegramChannel', () => {
           timestamp: '2024-01-01T00:00:00.000Z',
         }),
       );
+    });
+  });
+
+  // --- Self-message filtering ---
+
+  describe('self-message filtering', () => {
+    it('skips messages from the bot itself', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      // Bot ID is 12345 (from MockBot.start)
+      const ctx = createTextCtx({
+        text: 'Echo from bot',
+        fromId: 12345,
+        isBot: true,
+        firstName: 'Andy Bot',
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
+      expect(opts.onChatMetadata).not.toHaveBeenCalled();
+    });
+
+    it('delivers messages from other bots', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'Message from another bot',
+        fromId: 99999,
+        isBot: true,
+        firstName: 'Other Bot',
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: 'Message from another bot',
+          sender_name: 'Other Bot',
+        }),
+      );
+    });
+
+    it('skips non-text messages from the bot itself', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({
+        fromId: 12345,
+        isBot: true,
+        firstName: 'Andy Bot',
+      });
+      await triggerMediaMessage('message:photo', ctx);
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
     });
   });
 

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -47,6 +47,7 @@ export class TelegramChannel implements Channel {
   private bot: Bot | null = null;
   private opts: TelegramChannelOpts;
   private botToken: string;
+  private botUserId: number | null = null;
 
   constructor(botToken: string, opts: TelegramChannelOpts) {
     this.botToken = botToken;
@@ -85,6 +86,9 @@ export class TelegramChannel implements Channel {
     const TELEGRAM_BOT_COMMANDS = new Set(['chatid', 'ping']);
 
     this.bot.on('message:text', async (ctx) => {
+      // Skip messages from the bot itself to prevent loops
+      if (ctx.from?.is_bot && ctx.from?.id === this.botUserId) return;
+
       if (ctx.message.text.startsWith('/')) {
         const cmd = ctx.message.text.slice(1).split(/[\s@]/)[0].toLowerCase();
         if (TELEGRAM_BOT_COMMANDS.has(cmd)) return;
@@ -167,6 +171,9 @@ export class TelegramChannel implements Channel {
 
     // Handle non-text messages with placeholders so the agent knows something was sent
     const storeNonText = (ctx: any, placeholder: string) => {
+      // Skip messages from the bot itself to prevent loops
+      if (ctx.from?.is_bot && ctx.from?.id === this.botUserId) return;
+
       const chatJid = `tg:${ctx.chat.id}`;
       const group = this.opts.registeredGroups()[chatJid];
       if (!group) return;
@@ -223,6 +230,7 @@ export class TelegramChannel implements Channel {
     return new Promise<void>((resolve) => {
       this.bot!.start({
         onStart: (botInfo) => {
+          this.botUserId = botInfo.id;
           logger.info(
             { username: botInfo.username, id: botInfo.id },
             'Telegram bot connected',


### PR DESCRIPTION
## Type of Change
- [x] Fix

## Description
When the bot sends a message to a group, Telegram delivers it back via polling as an update. Without filtering, the bot processes its own messages, potentially creating infinite reply loops.

This PR adds `botUserId` tracking (set during `onStart`) and an early-return guard in both the `message:text` handler and `storeNonText` that skips messages where `ctx.from.is_bot && ctx.from.id === botUserId`. Messages from other bots are still delivered normally.

## Tests
- `skips messages from the bot itself` — verifies own messages are dropped
- `delivers messages from other bots` — verifies other bot messages pass through
- `skips non-text messages from the bot itself` — verifies media from self is dropped