### PR TITLE
fix: split long messages at natural boundaries

### DIFF
--- a/src/channels/telegram.test.ts
+++ b/src/channels/telegram.test.ts
@@ -69,7 +69,11 @@ vi.mock('grammy', () => ({
   },
 }));
 
-import { TelegramChannel, TelegramChannelOpts } from './telegram.js';
+import {
+  TelegramChannel,
+  TelegramChannelOpts,
+  splitMessage,
+} from './telegram.js';
 
 // --- Test helpers ---
 
@@ -798,6 +802,57 @@ describe('TelegramChannel', () => {
       await channel.sendMessage('tg:100200300', 'No bot');
 
       // No error, no API call
+    });
+  });
+
+  // --- splitMessage ---
+
+  describe('splitMessage', () => {
+    it('returns single chunk for short text', () => {
+      const result = splitMessage('Hello world');
+      expect(result).toEqual(['Hello world']);
+    });
+
+    it('splits at paragraph boundary when possible', () => {
+      const para1 = 'a'.repeat(3000);
+      const para2 = 'b'.repeat(3000);
+      const text = `${para1}\n\n${para2}`;
+      const result = splitMessage(text);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe(para1);
+      expect(result[1]).toBe(para2);
+    });
+
+    it('splits at newline when no paragraph boundary', () => {
+      const line1 = 'a'.repeat(3000);
+      const line2 = 'b'.repeat(2000);
+      const text = `${line1}\n${line2}`;
+      const result = splitMessage(text);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe(line1);
+      expect(result[1]).toBe(line2);
+    });
+
+    it('splits at space when no newline', () => {
+      const word1 = 'a'.repeat(3000);
+      const word2 = 'b'.repeat(2000);
+      const text = `${word1} ${word2}`;
+      const result = splitMessage(text);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe(word1);
+      expect(result[1]).toBe(word2);
+    });
+
+    it('hard splits when no natural boundary', () => {
+      const text = 'x'.repeat(5000);
+      const result = splitMessage(text);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe('x'.repeat(4096));
+      expect(result[1]).toBe('x'.repeat(904));
     });
   });
 

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -41,6 +41,38 @@ async function sendTelegramMessage(
   }
 }
 
+/**
+ * Split long text into chunks that respect natural boundaries.
+ * Tries paragraph breaks first, then newlines, then spaces, then hard cuts.
+ */
+export function splitMessage(text: string, maxLength = 4096): string[] {
+  if (text.length <= maxLength) return [text];
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    if (remaining.length <= maxLength) {
+      chunks.push(remaining);
+      break;
+    }
+
+    // Try to split at paragraph boundary first
+    let splitIdx = remaining.lastIndexOf('\n\n', maxLength);
+    // Then try single newline
+    if (splitIdx <= 0) splitIdx = remaining.lastIndexOf('\n', maxLength);
+    // Then try space
+    if (splitIdx <= 0) splitIdx = remaining.lastIndexOf(' ', maxLength);
+    // Last resort: hard cut
+    if (splitIdx <= 0) splitIdx = maxLength;
+
+    chunks.push(remaining.slice(0, splitIdx));
+    remaining = remaining.slice(splitIdx).replace(/^[\n ]+/, '');
+  }
+
+  return chunks;
+}
+
 export class TelegramChannel implements Channel {
   name = 'telegram';
 
@@ -247,17 +279,9 @@ export class TelegramChannel implements Channel {
       const numericId = jid.replace(/^tg:/, '');
 
       // Telegram has a 4096 character limit per message — split if needed
-      const MAX_LENGTH = 4096;
-      if (text.length <= MAX_LENGTH) {
-        await sendTelegramMessage(this.bot.api, numericId, text);
-      } else {
-        for (let i = 0; i < text.length; i += MAX_LENGTH) {
-          await sendTelegramMessage(
-            this.bot.api,
-            numericId,
-            text.slice(i, i + MAX_LENGTH),
-          );
-        }
+      const chunks = splitMessage(text);
+      for (const chunk of chunks) {
+        await sendTelegramMessage(this.bot.api, numericId, chunk);
       }
       logger.info({ jid, length: text.length }, 'Telegram message sent');
     } catch (err) {


### PR DESCRIPTION
## Type of Change
- [x] Fix

## Description
The previous implementation split messages exceeding 4096 characters with a hard `slice(i, i + 4096)`, which could break words and Markdown formatting mid-token.

This PR adds a `splitMessage()` function that tries to find a natural split point in this priority order: paragraph break (`\n\n`), single newline (`\n`), space (` `), and finally a hard cut as last resort.

## Tests
- `splits at paragraph boundary when possible`
- `splits at newline when no paragraph boundary`
- `splits at space when no newline`
- `hard splits when no natural boundary`