### PR TITLE
feat: add forum/topics support via thread ID tracking

### DIFF
--- a/src/channels/telegram.test.ts
+++ b/src/channels/telegram.test.ts
@@ -102,6 +102,7 @@ function createTextCtx(overrides: {
   messageId?: number;
   date?: number;
   entities?: any[];
+  messageThreadId?: number;
 }) {
   const chatId = overrides.chatId ?? 100200300;
   const chatType = overrides.chatType ?? 'group';
@@ -121,6 +122,7 @@ function createTextCtx(overrides: {
       date: overrides.date ?? Math.floor(Date.now() / 1000),
       message_id: overrides.messageId ?? 1,
       entities: overrides.entities ?? [],
+      message_thread_id: overrides.messageThreadId,
     },
     me: { username: 'andy_ai_bot' },
     reply: vi.fn(),
@@ -136,6 +138,7 @@ function createMediaCtx(overrides: {
   messageId?: number;
   caption?: string;
   extra?: Record<string, any>;
+  messageThreadId?: number;
 }) {
   const chatId = overrides.chatId ?? 100200300;
   return {
@@ -153,6 +156,7 @@ function createMediaCtx(overrides: {
       date: overrides.date ?? Math.floor(Date.now() / 1000),
       message_id: overrides.messageId ?? 1,
       caption: overrides.caption,
+      message_thread_id: overrides.messageThreadId,
       ...(overrides.extra || {}),
     },
     me: { username: 'andy_ai_bot' },
@@ -801,6 +805,90 @@ describe('TelegramChannel', () => {
     });
   });
 
+  // --- Forum/Topics support ---
+
+  describe('forum topics', () => {
+    it('tracks message_thread_id from incoming messages', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      // Send a message with a thread ID (forum topic)
+      const ctx = createTextCtx({
+        text: 'Hello from a topic',
+        messageThreadId: 42,
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ content: 'Hello from a topic' }),
+      );
+    });
+
+    it('sends reply to correct thread', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      // First, receive a message from a forum topic to track the thread
+      const ctx = createTextCtx({
+        text: 'Message in topic',
+        messageThreadId: 42,
+      });
+      await triggerTextMessage(ctx);
+
+      // Now send a reply — should include message_thread_id
+      await channel.sendMessage('tg:100200300', 'Reply');
+
+      expect(currentBot().api.sendMessage).toHaveBeenCalledWith(
+        '100200300',
+        'Reply',
+        { message_thread_id: 42, parse_mode: 'Markdown' },
+      );
+    });
+
+    it('sends typing indicator to correct thread', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      // Track a thread ID
+      const ctx = createTextCtx({
+        text: 'Topic message',
+        messageThreadId: 42,
+      });
+      await triggerTextMessage(ctx);
+
+      await channel.setTyping('tg:100200300', true);
+
+      expect(currentBot().api.sendChatAction).toHaveBeenCalledWith(
+        '100200300',
+        'typing',
+        { message_thread_id: 42 },
+      );
+    });
+
+    it('works without thread_id (non-forum groups)', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      // Send a message without thread ID
+      const ctx = createTextCtx({ text: 'Regular group message' });
+      await triggerTextMessage(ctx);
+
+      await channel.sendMessage('tg:100200300', 'Reply');
+
+      // Should not include message_thread_id
+      expect(currentBot().api.sendMessage).toHaveBeenCalledWith(
+        '100200300',
+        'Reply',
+        { parse_mode: 'Markdown' },
+      );
+    });
+  });
+
   // --- ownsJid ---
 
   describe('ownsJid', () => {
@@ -843,6 +931,7 @@ describe('TelegramChannel', () => {
       expect(currentBot().api.sendChatAction).toHaveBeenCalledWith(
         '100200300',
         'typing',
+        {},
       );
     });
 

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -47,6 +47,7 @@ export class TelegramChannel implements Channel {
   private bot: Bot | null = null;
   private opts: TelegramChannelOpts;
   private botToken: string;
+  private threadIds = new Map<string, number>();
 
   constructor(botToken: string, opts: TelegramChannelOpts) {
     this.botToken = botToken;
@@ -91,6 +92,10 @@ export class TelegramChannel implements Channel {
       }
 
       const chatJid = `tg:${ctx.chat.id}`;
+      // Track forum topic thread ID for replies
+      if (ctx.message.message_thread_id) {
+        this.threadIds.set(chatJid, ctx.message.message_thread_id);
+      }
       let content = ctx.message.text;
       const timestamp = new Date(ctx.message.date * 1000).toISOString();
       const senderName =
@@ -168,6 +173,10 @@ export class TelegramChannel implements Channel {
     // Handle non-text messages with placeholders so the agent knows something was sent
     const storeNonText = (ctx: any, placeholder: string) => {
       const chatJid = `tg:${ctx.chat.id}`;
+      // Track forum topic thread ID for replies
+      if (ctx.message?.message_thread_id) {
+        this.threadIds.set(chatJid, ctx.message.message_thread_id);
+      }
       const group = this.opts.registeredGroups()[chatJid];
       if (!group) return;
 
@@ -246,16 +255,21 @@ export class TelegramChannel implements Channel {
     try {
       const numericId = jid.replace(/^tg:/, '');
 
+      // Include forum thread ID if one was tracked for this chat
+      const threadId = this.threadIds.get(jid);
+      const options = threadId ? { message_thread_id: threadId } : {};
+
       // Telegram has a 4096 character limit per message — split if needed
       const MAX_LENGTH = 4096;
       if (text.length <= MAX_LENGTH) {
-        await sendTelegramMessage(this.bot.api, numericId, text);
+        await sendTelegramMessage(this.bot.api, numericId, text, options);
       } else {
         for (let i = 0; i < text.length; i += MAX_LENGTH) {
           await sendTelegramMessage(
             this.bot.api,
             numericId,
             text.slice(i, i + MAX_LENGTH),
+            options,
           );
         }
       }
@@ -285,7 +299,9 @@ export class TelegramChannel implements Channel {
     if (!this.bot || !isTyping) return;
     try {
       const numericId = jid.replace(/^tg:/, '');
-      await this.bot.api.sendChatAction(numericId, 'typing');
+      const threadId = this.threadIds.get(jid);
+      const options = threadId ? { message_thread_id: threadId } : {};
+      await this.bot.api.sendChatAction(numericId, 'typing', options);
     } catch (err) {
       logger.debug({ jid, err }, 'Failed to send Telegram typing indicator');
     }


### PR DESCRIPTION
## Type of Change
- [x] Skill

## Description
Telegram Forum supergroups use `message_thread_id` to route messages to specific topics. Without tracking this ID, the bot always replies in the General thread regardless of which topic the user messaged from.

This PR adds a `threadIds` map that stores the latest `message_thread_id` per chat JID from incoming messages (both text and non-text). Outgoing `sendMessage` and `setTyping` calls then include the tracked thread ID in their options, so replies land in the correct topic.

## Tests
- `tracks message_thread_id from incoming messages`
- `sends reply to correct thread`
- `sends typing indicator to correct thread`
- `works without thread_id (non-forum groups)`