### PR TITLE
feat: deliver emoji reactions as structured messages

### DIFF
--- a/src/channels/telegram.test.ts
+++ b/src/channels/telegram.test.ts
@@ -61,7 +61,7 @@ vi.mock('grammy', () => ({
       this.errorHandler = handler;
     }
 
-    start(opts: { onStart: (botInfo: any) => void }) {
+    start(opts: { onStart: (botInfo: any) => void; allowed_updates?: string[] }) {
       opts.onStart({ username: 'andy_ai_bot', id: 12345 });
     }
 
@@ -173,6 +173,19 @@ async function triggerMediaMessage(
   ctx: ReturnType<typeof createMediaCtx>,
 ) {
   const handlers = currentBot().filterHandlers.get(filter) || [];
+  for (const h of handlers) await h(ctx);
+}
+
+async function triggerReaction(ctx: {
+  messageReaction: {
+    chat: { id: number };
+    message_id: number;
+    date: number;
+    user?: { id: number; first_name?: string; username?: string };
+    new_reaction: Array<{ type: string; emoji?: string; custom_emoji_id?: string }>;
+  };
+}) {
+  const handlers = currentBot().filterHandlers.get('message_reaction') || [];
   for (const h of handlers) await h(ctx);
 }
 
@@ -798,6 +811,98 @@ describe('TelegramChannel', () => {
       await channel.sendMessage('tg:100200300', 'No bot');
 
       // No error, no API call
+    });
+  });
+
+  // --- Message reactions ---
+
+  describe('message reactions', () => {
+    it('delivers emoji reactions as messages', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await triggerReaction({
+        messageReaction: {
+          chat: { id: 100200300 },
+          message_id: 42,
+          date: 1704067200,
+          user: { id: 99001, first_name: 'Alice', username: 'alice_user' },
+          new_reaction: [{ type: 'emoji', emoji: '👍' }],
+        },
+      });
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          chat_jid: 'tg:100200300',
+          sender: '99001',
+          sender_name: 'Alice',
+          is_from_me: false,
+        }),
+      );
+
+      const msg = (opts.onMessage as any).mock.calls[0][1];
+      const parsed = JSON.parse(msg.content);
+      expect(parsed._type).toBe('message_reaction');
+      expect(parsed.emoji).toBe('👍');
+      expect(parsed.message_id).toBe(42);
+    });
+
+    it('ignores reactions from unregistered chats', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await triggerReaction({
+        messageReaction: {
+          chat: { id: 999999 },
+          message_id: 1,
+          date: 1704067200,
+          user: { id: 99001, first_name: 'Alice' },
+          new_reaction: [{ type: 'emoji', emoji: '👍' }],
+        },
+      });
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+
+    it('ignores reaction removals (empty new_reaction)', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await triggerReaction({
+        messageReaction: {
+          chat: { id: 100200300 },
+          message_id: 1,
+          date: 1704067200,
+          user: { id: 99001, first_name: 'Alice' },
+          new_reaction: [],
+        },
+      });
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+
+    it('ignores custom emoji reactions', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await triggerReaction({
+        messageReaction: {
+          chat: { id: 100200300 },
+          message_id: 1,
+          date: 1704067200,
+          user: { id: 99001, first_name: 'Alice' },
+          new_reaction: [
+            { type: 'custom_emoji', custom_emoji_id: '12345' },
+          ],
+        },
+      });
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
     });
   });
 

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -214,6 +214,45 @@ export class TelegramChannel implements Channel {
     this.bot.on('message:location', (ctx) => storeNonText(ctx, '[Location]'));
     this.bot.on('message:contact', (ctx) => storeNonText(ctx, '[Contact]'));
 
+    // Handle emoji reactions on messages
+    this.bot.on('message_reaction', async (ctx) => {
+      const update = ctx.messageReaction;
+      if (!update) return;
+
+      const chatJid = `tg:${update.chat.id}`;
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) return;
+
+      const newReactions = update.new_reaction || [];
+      if (newReactions.length === 0) return; // Reaction removed, ignore
+
+      const emoji = newReactions
+        .filter((r: any) => r.type === 'emoji')
+        .map((r: any) => r.emoji)
+        .join('');
+      if (!emoji) return; // Custom emoji only, skip
+
+      const senderName =
+        update.user?.first_name || update.user?.username || 'Unknown';
+      const timestamp = new Date(update.date * 1000).toISOString();
+
+      this.opts.onMessage(chatJid, {
+        id: `reaction-${update.message_id}-${Date.now()}`,
+        chat_jid: chatJid,
+        sender: update.user?.id?.toString() || '',
+        sender_name: senderName,
+        content: JSON.stringify({
+          _type: 'message_reaction',
+          emoji,
+          message_id: update.message_id,
+          from_name: senderName,
+          text: `[reaction: ${emoji}] on message #${update.message_id}`,
+        }),
+        timestamp,
+        is_from_me: false,
+      });
+    });
+
     // Handle errors gracefully
     this.bot.catch((err) => {
       logger.error({ err: err.message }, 'Telegram bot error');
@@ -222,6 +261,7 @@ export class TelegramChannel implements Channel {
     // Start polling — returns a Promise that resolves when started
     return new Promise<void>((resolve) => {
       this.bot!.start({
+        allowed_updates: ['message', 'message_reaction'],
         onStart: (botInfo) => {
           logger.info(
             { username: botInfo.username, id: botInfo.id },


### PR DESCRIPTION
## Type of Change
- [x] Skill

## Description
The bot previously had no visibility into message reactions. When users reacted to messages with emoji, the bot was unaware.

This PR registers for `message_reaction` updates via `allowed_updates` and converts incoming emoji reactions into structured JSON messages delivered through `onMessage`. The payload includes the emoji, the target message ID, and the sender name. Reaction removals (empty `new_reaction`) and custom emoji reactions are ignored.

## Tests
- `delivers emoji reactions as messages` — verifies emoji reactions produce structured JSON messages
- `ignores reactions from unregistered chats` — verifies unregistered chats are filtered
- `ignores reaction removals (empty new_reaction)` — verifies un-reactions are skipped
- `ignores custom emoji reactions` — verifies only standard emoji is forwarded