### PR TITLE
feat: support inline keyboard callback queries

### DIFF
--- a/src/channels/telegram.test.ts
+++ b/src/channels/telegram.test.ts
@@ -61,7 +61,10 @@ vi.mock('grammy', () => ({
       this.errorHandler = handler;
     }
 
-    start(opts: { onStart: (botInfo: any) => void }) {
+    start(opts: {
+      onStart: (botInfo: any) => void;
+      allowed_updates?: string[];
+    }) {
       opts.onStart({ username: 'andy_ai_bot', id: 12345 });
     }
 
@@ -176,6 +179,20 @@ async function triggerMediaMessage(
   for (const h of handlers) await h(ctx);
 }
 
+async function triggerCallbackQuery(ctx: {
+  callbackQuery: {
+    id: string;
+    from: { id: number; first_name?: string; username?: string };
+    message?: { chat: { id: number }; message_id: number };
+    data: string;
+  };
+  answerCallbackQuery: ReturnType<typeof vi.fn>;
+}) {
+  const handlers =
+    currentBot().filterHandlers.get('callback_query:data') || [];
+  for (const h of handlers) await h(ctx);
+}
+
 // --- Tests ---
 
 describe('TelegramChannel', () => {
@@ -216,6 +233,9 @@ describe('TelegramChannel', () => {
       expect(currentBot().filterHandlers.has('message:sticker')).toBe(true);
       expect(currentBot().filterHandlers.has('message:location')).toBe(true);
       expect(currentBot().filterHandlers.has('message:contact')).toBe(true);
+      expect(currentBot().filterHandlers.has('callback_query:data')).toBe(
+        true,
+      );
     });
 
     it('registers error handler on connect', async () => {
@@ -798,6 +818,105 @@ describe('TelegramChannel', () => {
       await channel.sendMessage('tg:100200300', 'No bot');
 
       // No error, no API call
+    });
+  });
+
+  // --- Callback queries ---
+
+  describe('callback queries', () => {
+    it('delivers callback query data as message', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const answerCallbackQuery = vi.fn().mockResolvedValue(undefined);
+      await triggerCallbackQuery({
+        callbackQuery: {
+          id: 'cbq-123',
+          from: { id: 99001, first_name: 'Alice', username: 'alice_user' },
+          message: { chat: { id: 100200300 }, message_id: 42 },
+          data: 'approve_task',
+        },
+        answerCallbackQuery,
+      });
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          id: 'callback-cbq-123',
+          chat_jid: 'tg:100200300',
+          sender: '99001',
+          sender_name: 'Alice',
+          is_from_me: false,
+        }),
+      );
+
+      const msg = (opts.onMessage as any).mock.calls[0][1];
+      const parsed = JSON.parse(msg.content);
+      expect(parsed._type).toBe('callback_query');
+      expect(parsed.data).toBe('approve_task');
+      expect(parsed.query_id).toBe('cbq-123');
+      expect(parsed.message_id).toBe(42);
+      expect(parsed.from_name).toBe('Alice');
+    });
+
+    it('acknowledges callback query', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const answerCallbackQuery = vi.fn().mockResolvedValue(undefined);
+      await triggerCallbackQuery({
+        callbackQuery: {
+          id: 'cbq-456',
+          from: { id: 99001, first_name: 'Alice' },
+          message: { chat: { id: 100200300 }, message_id: 10 },
+          data: 'click',
+        },
+        answerCallbackQuery,
+      });
+
+      expect(answerCallbackQuery).toHaveBeenCalled();
+    });
+
+    it('ignores callback queries from unregistered chats', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const answerCallbackQuery = vi.fn().mockResolvedValue(undefined);
+      await triggerCallbackQuery({
+        callbackQuery: {
+          id: 'cbq-789',
+          from: { id: 99001, first_name: 'Alice' },
+          message: { chat: { id: 999999 }, message_id: 1 },
+          data: 'click',
+        },
+        answerCallbackQuery,
+      });
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
+      expect(answerCallbackQuery).toHaveBeenCalled();
+    });
+
+    it('ignores callback queries without chat context', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const answerCallbackQuery = vi.fn().mockResolvedValue(undefined);
+      await triggerCallbackQuery({
+        callbackQuery: {
+          id: 'cbq-no-chat',
+          from: { id: 99001, first_name: 'Alice' },
+          message: undefined as any,
+          data: 'click',
+        },
+        answerCallbackQuery,
+      });
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
+      expect(answerCallbackQuery).not.toHaveBeenCalled();
     });
   });
 

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -214,6 +214,44 @@ export class TelegramChannel implements Channel {
     this.bot.on('message:location', (ctx) => storeNonText(ctx, '[Location]'));
     this.bot.on('message:contact', (ctx) => storeNonText(ctx, '[Contact]'));
 
+    // Handle inline keyboard button presses
+    this.bot.on('callback_query:data', async (ctx) => {
+      const query = ctx.callbackQuery;
+      const chatId = query.message?.chat?.id;
+      if (!chatId) return;
+
+      const chatJid = `tg:${chatId}`;
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) {
+        await ctx.answerCallbackQuery();
+        return;
+      }
+
+      const senderName =
+        query.from?.first_name || query.from?.username || 'Unknown';
+      const timestamp = new Date().toISOString();
+
+      this.opts.onMessage(chatJid, {
+        id: `callback-${query.id}`,
+        chat_jid: chatJid,
+        sender: query.from?.id?.toString() || '',
+        sender_name: senderName,
+        content: JSON.stringify({
+          _type: 'callback_query',
+          data: query.data,
+          query_id: query.id,
+          message_id: query.message?.message_id,
+          from_name: senderName,
+          text: `[button: ${query.data}] pressed by ${senderName}`,
+        }),
+        timestamp,
+        is_from_me: false,
+      });
+
+      // Acknowledge the callback to remove loading state
+      await ctx.answerCallbackQuery();
+    });
+
     // Handle errors gracefully
     this.bot.catch((err) => {
       logger.error({ err: err.message }, 'Telegram bot error');
@@ -222,6 +260,7 @@ export class TelegramChannel implements Channel {
     // Start polling — returns a Promise that resolves when started
     return new Promise<void>((resolve) => {
       this.bot!.start({
+        allowed_updates: ['message', 'callback_query'],
         onStart: (botInfo) => {
           logger.info(
             { username: botInfo.username, id: botInfo.id },


### PR DESCRIPTION
## Type of Change
- [x] Skill

## Description

When a user presses an inline keyboard button in Telegram, the bot receives a `callback_query` update. This PR handles those updates and delivers them to agents as structured JSON messages containing the button data, query ID, message ID, and sender info.

The callback is automatically acknowledged (`answerCallbackQuery`) to remove the loading spinner on the client.

This enables agents to create interactive flows using inline keyboards — for example, approval buttons, navigation menus, or quick-action shortcuts.

## Tests

Added 4 new test cases:
- Delivers callback query data as structured message
- Acknowledges callback query to remove loading state
- Ignores callbacks from unregistered chats (still acknowledges)
- Ignores callbacks without chat context