### PR TITLE
fix: auto-reconnect polling after transient errors (e.g. 409 Conflict)

### DIFF
--- a/src/channels/telegram.test.ts
+++ b/src/channels/telegram.test.ts
@@ -61,11 +61,20 @@ vi.mock('grammy', () => ({
       this.errorHandler = handler;
     }
 
-    start(opts: { onStart: (botInfo: any) => void }) {
-      opts.onStart({ username: 'andy_ai_bot', id: 12345 });
+    _startReject: ((err: any) => void) | null = null;
+
+    start(opts?: { onStart?: (botInfo: any) => void }) {
+      if (opts?.onStart) {
+        opts.onStart({ username: 'andy_ai_bot', id: 12345 });
+      }
+      return new Promise<void>((_resolve, reject) => {
+        this._startReject = reject;
+      });
     }
 
-    stop() {}
+    stop() {
+      return Promise.resolve();
+    }
   },
 }));
 
@@ -944,6 +953,67 @@ describe('TelegramChannel', () => {
     it('has name "telegram"', () => {
       const channel = new TelegramChannel('test-token', createTestOpts());
       expect(channel.name).toBe('telegram');
+    });
+  });
+
+  // --- Polling auto-reconnect ---
+
+  describe('polling auto-reconnect', () => {
+    it('restarts polling after a 409 Conflict error', async () => {
+      vi.useFakeTimers();
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const bot = currentBot();
+      const startSpy = vi.spyOn(bot, 'start');
+
+      // Simulate grammY rejecting with 409 Conflict
+      bot._startReject!({ error_code: 409, message: 'Conflict' });
+      await vi.advanceTimersByTimeAsync(3_000);
+
+      // bot.start() should have been called again (reconnect attempt)
+      expect(startSpy).toHaveBeenCalledTimes(1);
+
+      vi.useRealTimers();
+    });
+
+    it('does not retry on 401 Unauthorized', async () => {
+      vi.useFakeTimers();
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const bot = currentBot();
+      const startSpy = vi.spyOn(bot, 'start');
+
+      // Simulate 401
+      bot._startReject!({ error_code: 401, message: 'Unauthorized' });
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      // Should NOT retry
+      expect(startSpy).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+
+    it('does not retry after disconnect', async () => {
+      vi.useFakeTimers();
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const bot = currentBot();
+      const startSpy = vi.spyOn(bot, 'start');
+
+      await channel.disconnect();
+      bot._startReject!({ error_code: 409, message: 'Conflict' });
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      // Should NOT retry — we're shutting down
+      expect(startSpy).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
     });
   });
 });

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -47,6 +47,7 @@ export class TelegramChannel implements Channel {
   private bot: Bot | null = null;
   private opts: TelegramChannelOpts;
   private botToken: string;
+  private stopping = false;
 
   constructor(botToken: string, opts: TelegramChannelOpts) {
     this.botToken = botToken;
@@ -219,7 +220,7 @@ export class TelegramChannel implements Channel {
       logger.error({ err: err.message }, 'Telegram bot error');
     });
 
-    // Start polling — returns a Promise that resolves when started
+    // Start polling — returns a Promise that resolves when onStart fires
     return new Promise<void>((resolve) => {
       this.bot!.start({
         onStart: (botInfo) => {
@@ -233,8 +234,37 @@ export class TelegramChannel implements Channel {
           );
           resolve();
         },
-      });
+      }).catch((err) => this.handlePollingFailure(err));
     });
+  }
+
+  /**
+   * Restart polling with exponential backoff when transient errors (e.g. 409
+   * Conflict during restarts) kill the grammY polling loop.  401 (invalid
+   * token) is treated as fatal and not retried.
+   */
+  private handlePollingFailure(err: any, attempt = 1): void {
+    if (this.stopping || !this.bot) return;
+
+    const code = err?.error_code;
+    if (code === 401) {
+      logger.error({ err }, 'Telegram bot auth failed, not retrying');
+      return;
+    }
+
+    const maxDelay = 60_000;
+    const delay = Math.min(3_000 * 2 ** (attempt - 1), maxDelay);
+    logger.warn(
+      { attempt, delay, err: err?.message || String(err) },
+      `Telegram polling failed, restarting in ${delay}ms`,
+    );
+
+    setTimeout(() => {
+      if (this.stopping || !this.bot) return;
+      this.bot.start().catch((retryErr) =>
+        this.handlePollingFailure(retryErr, Math.min(attempt + 1, 10)),
+      );
+    }, delay);
   }
 
   async sendMessage(jid: string, text: string): Promise<void> {
@@ -274,8 +304,9 @@ export class TelegramChannel implements Channel {
   }
 
   async disconnect(): Promise<void> {
+    this.stopping = true;
     if (this.bot) {
-      this.bot.stop();
+      await this.bot.stop();
       this.bot = null;
       logger.info('Telegram bot stopped');
     }


### PR DESCRIPTION
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

grammY treats 409 Conflict as a fatal error and exits the polling loop permanently. This happens during process restarts when the old long-poll TCP connection hasn't closed yet — Telegram returns 409 to the new instance, grammY rethrows, and `bot.start()` rejects. Since the returned promise has no `.catch()` handler, the polling loop dies silently and the bot stops receiving all messages.

**What this PR does:**
- Adds `.catch()` on `bot.start()` with a `handlePollingFailure()` method
- Retries with exponential backoff (3s → 6s → 12s → ... → 60s max)
- 401 (invalid token) is treated as fatal and not retried
- `disconnect()` now awaits `bot.stop()` and sets a `stopping` flag to prevent reconnect attempts during shutdown

**What it doesn't do:** No new features, no behavior changes for the happy path.

## Tests

Added 3 test cases (254 total, all passing):
- `restarts polling after a 409 Conflict error`
- `does not retry on 401 Unauthorized`
- `does not retry after disconnect`