### PR TITLE
feat(skill): add voice transcription skill definition

### DIFF
--- a/.claude/skills/add-voice-transcription/SKILL.md
+++ b/.claude/skills/add-voice-transcription/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: add-voice-transcription
-description: Add voice message transcription to NanoClaw using OpenAI's Whisper API. Automatically transcribes WhatsApp voice notes so the agent can read and respond to them.
+description: Add voice message transcription to NanoClaw's Telegram channel using OpenAI's Whisper API. Automatically transcribes Telegram voice notes so the agent can read and respond to them.
 ---
 
 # Add Voice Transcription
 
-This skill adds automatic voice message transcription to NanoClaw's WhatsApp channel using OpenAI's Whisper API. When a voice note arrives, it is downloaded, transcribed, and delivered to the agent as `[Voice: <transcript>]`.
+This skill adds automatic voice message transcription to NanoClaw's Telegram channel using OpenAI's Whisper API. When a voice note arrives, it is downloaded, transcribed, and delivered to the agent as `[Voice: <transcript>]`. Falls back silently to `[Voice message]` if no key is configured or transcription fails.
 
 ## Phase 1: Pre-flight
 
@@ -23,25 +23,11 @@ If yes, collect it now. If no, direct them to create one at https://platform.ope
 
 ## Phase 2: Apply Code Changes
 
-**Prerequisite:** WhatsApp must be installed first (`skill/whatsapp` merged). This skill modifies WhatsApp channel files.
-
-### Ensure WhatsApp fork remote
-
-```bash
-git remote -v
-```
-
-If `whatsapp` is missing, add it:
-
-```bash
-git remote add whatsapp https://github.com/qwibitai/nanoclaw-whatsapp.git
-```
-
 ### Merge the skill branch
 
 ```bash
-git fetch whatsapp skill/voice-transcription
-git merge whatsapp/skill/voice-transcription || {
+git fetch origin skill/voice-transcription
+git merge origin/skill/voice-transcription || {
   git checkout --theirs package-lock.json
   git add package-lock.json
   git merge --continue
@@ -49,10 +35,9 @@ git merge whatsapp/skill/voice-transcription || {
 ```
 
 This merges in:
-- `src/transcription.ts` (voice transcription module using OpenAI Whisper)
-- Voice handling in `src/channels/whatsapp.ts` (isVoiceMessage check, transcribeAudioMessage call)
-- Transcription tests in `src/channels/whatsapp.test.ts`
-- `openai` npm dependency in `package.json`
+- `src/transcription.ts` — provider-based transcription module (OpenAI Whisper via raw `fetch`, no `openai` npm dependency)
+- `src/transcription.test.ts` — unit tests for the transcription module
+- Voice handling in `src/channels/telegram.ts` — downloads voice audio from Telegram Bot API, transcribes via provider
 - `OPENAI_API_KEY` in `.env.example`
 
 If the merge reports conflicts, resolve them by reading the conflicted files and understanding the intent of both sides.
@@ -60,9 +45,9 @@ If the merge reports conflicts, resolve them by reading the conflicted files and
 ### Validate code changes
 
 ```bash
-npm install --legacy-peer-deps
 npm run build
-npx vitest run src/channels/whatsapp.test.ts
+npx vitest run src/transcription.test.ts
+npx vitest run src/channels/telegram.test.ts
 ```
 
 All tests must pass and build must be clean before proceeding.
@@ -114,7 +99,7 @@ launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
 
 Tell the user:
 
-> Send a voice note in any registered WhatsApp chat. The agent should receive it as `[Voice: <transcript>]` and respond to its content.
+> Send a voice note in any registered Telegram chat. The agent should receive it as `[Voice: <transcript>]` and respond to its content.
 
 ### Check logs if needed
 
@@ -123,25 +108,17 @@ tail -f logs/nanoclaw.log | grep -i voice
 ```
 
 Look for:
-- `Transcribed voice message` — successful transcription with character count
-- `OPENAI_API_KEY not set` — key missing from `.env`
-- `OpenAI transcription failed` — API error (check key validity, billing)
-- `Failed to download audio message` — media download issue
+- `Voice transcription enabled` — provider initialized on startup
+- `Voice download/transcription failed` — API error (check key validity, billing)
+- No voice log lines — `OPENAI_API_KEY` not set, transcription disabled silently
 
 ## Troubleshooting
 
-### Voice notes show "[Voice Message - transcription unavailable]"
+### Voice notes show "[Voice message]" instead of transcript
 
 1. Check `OPENAI_API_KEY` is set in `.env` AND synced to `data/env/env`
 2. Verify key works: `curl -s https://api.openai.com/v1/models -H "Authorization: Bearer $OPENAI_API_KEY" | head -c 200`
 3. Check OpenAI billing — Whisper requires a funded account
-
-### Voice notes show "[Voice Message - transcription failed]"
-
-Check logs for the specific error. Common causes:
-- Network timeout — transient, will work on next message
-- Invalid API key — regenerate at https://platform.openai.com/api-keys
-- Rate limiting — wait and retry
 
 ### Agent doesn't respond to voice notes
 


### PR DESCRIPTION
## Type of Change

- [x] **Skill** - adds a new skill in `.claude/skills/`

## Description

Adds the `/add-voice-transcription` skill definition to `main`. This skill lets users merge voice transcription support from the `skill/voice-transcription` branch into their fork.

The actual code changes (transcription module, Telegram handler, tests) are in PR #137, which should be merged into a `skill/voice-transcription` branch on upstream.

### What changed

- **`.claude/skills/add-voice-transcription/SKILL.md`** — Updated for Telegram (was WhatsApp-oriented). References `origin skill/voice-transcription` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)