### PR TITLE
skill: add /add-telegram-threads-autoregistration

### DIFF
--- a/.claude/skills/add-telegram-threads-autoregistration/SKILL.md
+++ b/.claude/skills/add-telegram-threads-autoregistration/SKILL.md
@@ -13,7 +13,7 @@ This skill makes NanoClaw automatically register each Telegram forum thread as i
 
 - When a message arrives in a thread of a registered supergroup, the host checks whether a group for `tg:<chatId>:<threadId>` exists
 - If not, it auto-registers it using the cached forum topic name (if available) or `Thread <id>` as the group name
-- The thread group folder is `tg<chatId>-<threadId>` (numeric only, collision-free)
+- The thread group folder is `<parentFolder>_<threadSlug>` (e.g. `telegram_mygroup_support`) — readable and derived from the parent group's folder and the topic name
 - From that point on, messages in the thread are routed to its own isolated group context
 
 ## Implementation
@@ -62,10 +62,14 @@ private autoRegisterThread(
 ): void {
   if (!this.opts.registerGroup) return;
   const jid = `tg:${chatId}:${threadId}`;
-  const safeId = String(chatId).replace(/[^0-9]/g, '');
-  const folder = `tg${safeId}-${threadId}`;
   const name =
     this.topicNames.get(`${chatId}:${threadId}`) || `Thread ${threadId}`;
+  const threadSlug =
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '_')
+      .replace(/^_+|_+$/g, '') || `thread_${threadId}`;
+  const folder = `${parentGroup.folder}_${threadSlug}`.slice(0, 64);
   this.opts.registerGroup(jid, {
     name,
     folder,
@@ -124,7 +128,7 @@ Tell the user:
 ## Architecture Notes
 
 - Auto-registration happens on first message — threads that are never messaged are never registered
-- The thread folder is derived deterministically from the chat and thread IDs, so it is stable across restarts
+- The thread folder is derived from the parent group's folder and the topic name slug, so it is human-readable (e.g. `telegram_mygroup_support`) and stable as long as the topic name doesn't change
 - If the forum topic name is not cached yet (e.g. the bot restarted after the topic was created), the group name falls back to `Thread <id>` and can be renamed manually
 - The parent group's trigger, `requiresTrigger`, and `containerConfig` are all inherited
 

--- a/.claude/skills/add-telegram-threads-autoregistration/SKILL.md
+++ b/.claude/skills/add-telegram-threads-autoregistration/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: add-telegram-threads-autoregistration
+description: Auto-register Telegram forum threads as isolated groups. Each new thread in a registered supergroup gets its own group context automatically. Requires Telegram channel with thread support (use /add-telegram then apply the telegram-threads branch). Triggers on "auto-register threads", "telegram threads", "forum topics isolation".
+---
+
+# Add Auto-Register Telegram Threads
+
+This skill makes NanoClaw automatically register each Telegram forum thread as its own isolated group the first time a message is received in it. The thread inherits the parent group's trigger, container config, and `requiresTrigger` setting.
+
+**Prerequisite**: The Telegram channel must be set up with forum thread support. The `TelegramChannel` class in `src/channels/telegram.ts` must already have a `topicNames` map and `forum_topic_created`/`forum_topic_edited` listeners. If those are not present, apply the telegram-threads changes first.
+
+## How It Works
+
+- When a message arrives in a thread of a registered supergroup, the host checks whether a group for `tg:<chatId>:<threadId>` exists
+- If not, it auto-registers it using the cached forum topic name (if available) or `Thread <id>` as the group name
+- The thread group folder is `tg<chatId>-<threadId>` (numeric only, collision-free)
+- From that point on, messages in the thread are routed to its own isolated group context
+
+## Implementation
+
+### Step 1: Expose `registerGroup` to channels
+
+Read `src/channels/registry.ts`. Add an optional `registerGroup` callback to the `ChannelOpts` interface so channels can register new groups at runtime:
+
+```typescript
+registerGroup?: (jid: string, group: RegisteredGroup) => void;
+```
+
+Import `RegisteredGroup` from `../types.js` if it is not already imported.
+
+### Step 2: Wire `registerGroup` into channel opts
+
+Read `src/index.ts`. Find where `channelOpts` is constructed and add `registerGroup` to it:
+
+```typescript
+registerGroup,
+```
+
+The `registerGroup` function already exists in `index.ts` — this just makes it accessible to channels.
+
+### Step 3: Update the Telegram channel
+
+Read `src/channels/telegram.ts` in full before making any changes.
+
+#### 3a. Add `registerGroup` to `TelegramChannelOpts`
+
+Add the optional callback to the `TelegramChannelOpts` interface:
+
+```typescript
+registerGroup?: (jid: string, group: RegisteredGroup) => void;
+```
+
+#### 3b. Add the `autoRegisterThread` private method
+
+Add this method to `TelegramChannel`:
+
+```typescript
+private autoRegisterThread(
+  chatId: number | string,
+  threadId: number,
+  parentGroup: RegisteredGroup,
+): void {
+  if (!this.opts.registerGroup) return;
+  const jid = `tg:${chatId}:${threadId}`;
+  const safeId = String(chatId).replace(/[^0-9]/g, '');
+  const folder = `tg${safeId}-${threadId}`;
+  const name =
+    this.topicNames.get(`${chatId}:${threadId}`) || `Thread ${threadId}`;
+  this.opts.registerGroup(jid, {
+    name,
+    folder,
+    trigger: parentGroup.trigger,
+    added_at: new Date().toISOString(),
+    containerConfig: parentGroup.containerConfig,
+    requiresTrigger: parentGroup.requiresTrigger,
+  });
+  logger.info({ jid, name, folder }, 'Auto-registered Telegram thread');
+}
+```
+
+#### 3c. Auto-register in the text message handler
+
+In the `message:text` handler, after resolving `threadId`, `baseJid`, and `threadJid`, and after calling `this.opts.registeredGroups()`, add the auto-register check before resolving `chatJid`:
+
+```typescript
+if (threadId && threadJid && !groups[threadJid] && groups[baseJid]) {
+  this.autoRegisterThread(ctx.chat.id, threadId, groups[baseJid]);
+  groups = this.opts.registeredGroups();
+}
+```
+
+The variable holding registered groups must be declared with `let` so it can be reassigned after registration.
+
+#### 3d. Auto-register in the non-text message handler
+
+Apply the same pattern inside the `storeNonText` helper. After resolving `threadId`, `baseJid`, `threadJid`, and calling `registeredGroups()`, add:
+
+```typescript
+if (threadId && threadJid && !groups[threadJid] && groups[baseJid]) {
+  this.autoRegisterThread(ctx.chat.id, threadId, groups[baseJid]);
+  groups = this.opts.registeredGroups();
+}
+```
+
+### Step 4: Build and restart
+
+```bash
+npm run build
+# macOS:
+launchctl unload ~/Library/LaunchAgents/com.nanoclaw.plist
+launchctl load ~/Library/LaunchAgents/com.nanoclaw.plist
+# Linux:
+systemctl --user restart nanoclaw
+```
+
+### Step 5: Test
+
+Tell the user:
+
+> Send a message in any thread of a registered Telegram supergroup. Then run `/chatid` in that thread — you should see a thread-scoped JID (`tg:<chatId>:<threadId>`). Check the groups list to confirm it was auto-registered.
+>
+> Check logs: `grep "Auto-registered" logs/nanoclaw.log`
+
+## Architecture Notes
+
+- Auto-registration happens on first message — threads that are never messaged are never registered
+- The thread folder is derived deterministically from the chat and thread IDs, so it is stable across restarts
+- If the forum topic name is not cached yet (e.g. the bot restarted after the topic was created), the group name falls back to `Thread <id>` and can be renamed manually
+- The parent group's trigger, `requiresTrigger`, and `containerConfig` are all inherited
+
+## Removal
+
+To remove auto-register thread support:
+
+1. Remove the `autoRegisterThread` method from `TelegramChannel`
+2. Remove the auto-register checks from the `message:text` handler and `storeNonText`
+3. Remove `registerGroup?` from `TelegramChannelOpts`
+4. Remove `registerGroup?` from `ChannelOpts` in `src/channels/registry.ts` (only if no other channel uses it)
+5. Remove `registerGroup` from `channelOpts` in `src/index.ts` (only if no other channel uses it)
+6. Rebuild and restart

--- a/src/channels/telegram.test.ts
+++ b/src/channels/telegram.test.ts
@@ -69,7 +69,12 @@ vi.mock('grammy', () => ({
   },
 }));
 
-import { TelegramChannel, TelegramChannelOpts } from './telegram.js';
+import {
+  TelegramChannel,
+  TelegramChannelOpts,
+  resolveJid,
+  formatChatIdReply,
+} from './telegram.js';
 
 // --- Test helpers ---
 
@@ -102,6 +107,7 @@ function createTextCtx(overrides: {
   messageId?: number;
   date?: number;
   entities?: any[];
+  threadId?: number;
 }) {
   const chatId = overrides.chatId ?? 100200300;
   const chatType = overrides.chatType ?? 'group';
@@ -121,6 +127,7 @@ function createTextCtx(overrides: {
       date: overrides.date ?? Math.floor(Date.now() / 1000),
       message_id: overrides.messageId ?? 1,
       entities: overrides.entities ?? [],
+      message_thread_id: overrides.threadId,
     },
     me: { username: 'andy_ai_bot' },
     reply: vi.fn(),
@@ -136,6 +143,7 @@ function createMediaCtx(overrides: {
   messageId?: number;
   caption?: string;
   extra?: Record<string, any>;
+  threadId?: number;
 }) {
   const chatId = overrides.chatId ?? 100200300;
   return {
@@ -153,6 +161,7 @@ function createMediaCtx(overrides: {
       date: overrides.date ?? Math.floor(Date.now() / 1000),
       message_id: overrides.messageId ?? 1,
       caption: overrides.caption,
+      message_thread_id: overrides.threadId,
       ...(overrides.extra || {}),
     },
     me: { username: 'andy_ai_bot' },
@@ -176,7 +185,119 @@ async function triggerMediaMessage(
   for (const h of handlers) await h(ctx);
 }
 
-// --- Tests ---
+async function triggerForumTopicCreated(ctx: {
+  chat: { id: number };
+  message: { message_thread_id: number; forum_topic_created: { name: string } };
+}) {
+  const handlers =
+    currentBot().filterHandlers.get('message:forum_topic_created') || [];
+  for (const h of handlers) await h(ctx);
+}
+
+async function triggerForumTopicEdited(ctx: {
+  chat: { id: number };
+  message: { message_thread_id: number; forum_topic_edited: { name?: string } };
+}) {
+  const handlers =
+    currentBot().filterHandlers.get('message:forum_topic_edited') || [];
+  for (const h of handlers) await h(ctx);
+}
+
+// --- Pure function tests ---
+
+describe('resolveJid', () => {
+  it('returns base JID when there is no thread ID', () => {
+    expect(resolveJid(123, undefined, {})).toBe('tg:123');
+  });
+
+  it('returns base JID when thread is not registered', () => {
+    expect(
+      resolveJid(123, 456, {
+        'tg:123': { name: 'G', folder: 'g', trigger: '', added_at: '' },
+      }),
+    ).toBe('tg:123');
+  });
+
+  it('returns thread JID when thread is registered', () => {
+    expect(
+      resolveJid(123, 456, {
+        'tg:123:456': { name: 'T', folder: 't', trigger: '', added_at: '' },
+      }),
+    ).toBe('tg:123:456');
+  });
+
+  it('prefers thread JID over base JID when both are registered', () => {
+    const groups = {
+      'tg:123': { name: 'G', folder: 'g', trigger: '', added_at: '' },
+      'tg:123:456': { name: 'T', folder: 't', trigger: '', added_at: '' },
+    };
+    expect(resolveJid(123, 456, groups)).toBe('tg:123:456');
+  });
+
+  it('falls back to base JID for a different unregistered thread in the same chat', () => {
+    expect(
+      resolveJid(123, 789, {
+        'tg:123:456': { name: 'T', folder: 't', trigger: '', added_at: '' },
+      }),
+    ).toBe('tg:123');
+  });
+
+  it('handles string chatId', () => {
+    expect(
+      resolveJid('-100987', 10, {
+        'tg:-100987:10': { name: 'T', folder: 't', trigger: '', added_at: '' },
+      }),
+    ).toBe('tg:-100987:10');
+  });
+});
+
+describe('formatChatIdReply', () => {
+  it('formats a plain (non-thread) reply', () => {
+    const result = formatChatIdReply(123, undefined, 'My Chat', 'private');
+    expect(result).toBe('Chat ID: `tg:123`\nName: My Chat\nType: private');
+  });
+
+  it('formats a thread reply without a cached topic name', () => {
+    const result = formatChatIdReply(-100123, 456, 'My Group', 'supergroup');
+    expect(result).toContain('`tg:-100123:456`');
+    expect(result).toContain('_(register to isolate this thread)_');
+    expect(result).toContain('`tg:-100123`');
+    expect(result).toContain('My Group');
+    expect(result).toContain('supergroup');
+  });
+
+  it('includes topic name in the thread line when provided', () => {
+    const result = formatChatIdReply(
+      -100123,
+      456,
+      'My Group',
+      'supergroup',
+      'Support',
+    );
+    expect(result).toContain('`tg:-100123:456` — Support');
+  });
+
+  it('shows parent chat name on the base JID line, not the topic name', () => {
+    const result = formatChatIdReply(
+      -100123,
+      456,
+      'My Group',
+      'supergroup',
+      'Support',
+    );
+    const lines = result.split('\n');
+    const chatLine = lines.find((l) => l.startsWith('Chat ID:'))!;
+    expect(chatLine).toContain('My Group');
+    expect(chatLine).not.toContain('Support');
+  });
+
+  it('omits a standalone Name line for thread replies', () => {
+    const result = formatChatIdReply(-100123, 456, 'My Group', 'supergroup');
+    expect(result).not.toMatch(/^Name:/m);
+  });
+});
+
+// --- Class tests ---
 
 describe('TelegramChannel', () => {
   beforeEach(() => {
@@ -944,6 +1065,401 @@ describe('TelegramChannel', () => {
     it('has name "telegram"', () => {
       const channel = new TelegramChannel('test-token', createTestOpts());
       expect(channel.name).toBe('telegram');
+    });
+  });
+
+  // --- Thread (forum topic) routing ---
+
+  describe('thread routing', () => {
+    function threadOpts(threadJid = 'tg:100200300:456') {
+      return createTestOpts({
+        registeredGroups: vi.fn(() => ({
+          [threadJid]: {
+            name: 'Support Thread',
+            folder: 'support-thread',
+            trigger: '@Andy',
+            added_at: '2024-01-01T00:00:00.000Z',
+          },
+        })),
+      });
+    }
+
+    it('routes text message to thread JID when thread is registered', async () => {
+      const opts = threadOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'Hello', threadId: 456 });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300:456',
+        expect.objectContaining({ chat_jid: 'tg:100200300:456' }),
+      );
+    });
+
+    it('falls back to base JID when thread is not registered', async () => {
+      const opts = createTestOpts(); // only 'tg:100200300' registered, not the thread
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'Hello', threadId: 456 });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({ chat_jid: 'tg:100200300' }),
+      );
+    });
+
+    it('routes non-text message to thread JID when thread is registered', async () => {
+      const opts = threadOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createMediaCtx({ threadId: 456 });
+      await triggerMediaMessage('message:photo', ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300:456',
+        expect.objectContaining({
+          chat_jid: 'tg:100200300:456',
+          content: '[Photo]',
+        }),
+      );
+    });
+
+    it('uses topic name as chatName for thread-scoped messages', async () => {
+      const opts = threadOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      // Seed the topic name cache
+      await triggerForumTopicCreated({
+        chat: { id: 100200300 },
+        message: {
+          message_thread_id: 456,
+          forum_topic_created: { name: 'Support' },
+        },
+      });
+
+      const ctx = createTextCtx({ text: 'Help please', threadId: 456 });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'tg:100200300:456',
+        expect.any(String),
+        'Support',
+        'telegram',
+        true,
+      );
+    });
+
+    it('falls back to parent chat title when topic name not cached', async () => {
+      const opts = threadOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'Hello',
+        threadId: 456,
+        chatTitle: 'My Group',
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'tg:100200300:456',
+        expect.any(String),
+        'My Group',
+        'telegram',
+        true,
+      );
+    });
+  });
+
+  // --- Topic name caching ---
+
+  describe('topic name caching', () => {
+    it('caches topic name on forum_topic_created', async () => {
+      const opts = createTestOpts({
+        registeredGroups: vi.fn(() => ({
+          'tg:100200300:10': {
+            name: 'Thread',
+            folder: 'thread',
+            trigger: '@Andy',
+            added_at: '2024-01-01T00:00:00.000Z',
+          },
+        })),
+      });
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await triggerForumTopicCreated({
+        chat: { id: 100200300 },
+        message: {
+          message_thread_id: 10,
+          forum_topic_created: { name: 'Announcements' },
+        },
+      });
+
+      // Verify the name is used in subsequent messages
+      const ctx = createTextCtx({ text: 'Hi', threadId: 10 });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'tg:100200300:10',
+        expect.any(String),
+        'Announcements',
+        'telegram',
+        true,
+      );
+    });
+
+    it('updates cached topic name on forum_topic_edited', async () => {
+      const opts = createTestOpts({
+        registeredGroups: vi.fn(() => ({
+          'tg:100200300:10': {
+            name: 'Thread',
+            folder: 'thread',
+            trigger: '@Andy',
+            added_at: '2024-01-01T00:00:00.000Z',
+          },
+        })),
+      });
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await triggerForumTopicCreated({
+        chat: { id: 100200300 },
+        message: {
+          message_thread_id: 10,
+          forum_topic_created: { name: 'Old Name' },
+        },
+      });
+
+      await triggerForumTopicEdited({
+        chat: { id: 100200300 },
+        message: {
+          message_thread_id: 10,
+          forum_topic_edited: { name: 'New Name' },
+        },
+      });
+
+      const ctx = createTextCtx({ text: 'Hi', threadId: 10 });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'tg:100200300:10',
+        expect.any(String),
+        'New Name',
+        'telegram',
+        true,
+      );
+    });
+
+    it('ignores forum_topic_edited when name field is absent', async () => {
+      const opts = createTestOpts({
+        registeredGroups: vi.fn(() => ({
+          'tg:100200300:10': {
+            name: 'Thread',
+            folder: 'thread',
+            trigger: '@Andy',
+            added_at: '2024-01-01T00:00:00.000Z',
+          },
+        })),
+      });
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await triggerForumTopicCreated({
+        chat: { id: 100200300 },
+        message: {
+          message_thread_id: 10,
+          forum_topic_created: { name: 'Stable Name' },
+        },
+      });
+
+      // forum_topic_edited without name (e.g. only icon changed)
+      await triggerForumTopicEdited({
+        chat: { id: 100200300 },
+        message: {
+          message_thread_id: 10,
+          forum_topic_edited: { name: undefined },
+        },
+      });
+
+      const ctx = createTextCtx({ text: 'Hi', threadId: 10 });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'tg:100200300:10',
+        expect.any(String),
+        'Stable Name', // unchanged
+        'telegram',
+        true,
+      );
+    });
+  });
+
+  // --- Thread-aware commands ---
+
+  describe('/chatid in threads', () => {
+    it('shows thread JID and base JID when called inside a thread', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const handler = currentBot().commandHandlers.get('chatid')!;
+      const ctx = {
+        chat: { id: 100200300, type: 'supergroup' as const },
+        from: { first_name: 'Alice' },
+        message: { message_thread_id: 456 },
+        reply: vi.fn(),
+      };
+
+      await handler(ctx);
+
+      const reply: string = ctx.reply.mock.calls[0][0];
+      expect(reply).toContain('tg:100200300:456');
+      expect(reply).toContain('tg:100200300');
+      expect(reply).toContain('register to isolate this thread');
+    });
+
+    it('includes cached topic name in thread line', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await triggerForumTopicCreated({
+        chat: { id: 100200300 },
+        message: {
+          message_thread_id: 456,
+          forum_topic_created: { name: 'Bug Reports' },
+        },
+      });
+
+      const handler = currentBot().commandHandlers.get('chatid')!;
+      const ctx = {
+        chat: { id: 100200300, type: 'supergroup' as const },
+        from: { first_name: 'Alice' },
+        message: { message_thread_id: 456 },
+        reply: vi.fn(),
+      };
+
+      await handler(ctx);
+
+      const reply: string = ctx.reply.mock.calls[0][0];
+      expect(reply).toContain('Bug Reports');
+    });
+
+    it('omits topic name when not cached', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const handler = currentBot().commandHandlers.get('chatid')!;
+      const ctx = {
+        chat: { id: 100200300, type: 'supergroup' as const },
+        from: { first_name: 'Alice' },
+        message: { message_thread_id: 456 },
+        reply: vi.fn(),
+      };
+
+      await handler(ctx);
+
+      const reply: string = ctx.reply.mock.calls[0][0];
+      // Thread JID present but no " — TopicName" suffix
+      expect(reply).toMatch(/`tg:100200300:456`\s*_\(register/);
+    });
+  });
+
+  describe('/ping in threads', () => {
+    it('replies with message_thread_id when called inside a thread', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const handler = currentBot().commandHandlers.get('ping')!;
+      const ctx = {
+        message: { message_thread_id: 456 },
+        reply: vi.fn(),
+      };
+
+      await handler(ctx);
+
+      expect(ctx.reply).toHaveBeenCalledWith('Andy is online.', {
+        message_thread_id: 456,
+      });
+    });
+
+    it('replies without extra options outside a thread', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const handler = currentBot().commandHandlers.get('ping')!;
+      const ctx = { reply: vi.fn() };
+
+      await handler(ctx);
+
+      expect(ctx.reply).toHaveBeenCalledWith('Andy is online.');
+    });
+  });
+
+  // --- Thread-aware sendMessage and setTyping ---
+
+  describe('sendMessage with thread JID', () => {
+    it('passes message_thread_id for thread-scoped JIDs', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await channel.sendMessage('tg:100200300:456', 'Thread reply');
+
+      expect(currentBot().api.sendMessage).toHaveBeenCalledWith(
+        '100200300',
+        'Thread reply',
+        { parse_mode: 'Markdown', message_thread_id: 456 },
+      );
+    });
+
+    it('passes message_thread_id when splitting long messages', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const longText = 'x'.repeat(5000);
+      await channel.sendMessage('tg:100200300:456', longText);
+
+      expect(currentBot().api.sendMessage).toHaveBeenCalledTimes(2);
+      expect(currentBot().api.sendMessage).toHaveBeenNthCalledWith(
+        1,
+        '100200300',
+        'x'.repeat(4096),
+        { parse_mode: 'Markdown', message_thread_id: 456 },
+      );
+      expect(currentBot().api.sendMessage).toHaveBeenNthCalledWith(
+        2,
+        '100200300',
+        'x'.repeat(904),
+        { parse_mode: 'Markdown', message_thread_id: 456 },
+      );
+    });
+  });
+
+  describe('setTyping with thread JID', () => {
+    it('passes message_thread_id for thread-scoped JIDs', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await channel.setTyping('tg:100200300:456', true);
+
+      expect(currentBot().api.sendChatAction).toHaveBeenCalledWith(
+        '100200300',
+        'typing',
+        { message_thread_id: 456 },
+      );
     });
   });
 });

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -19,6 +19,49 @@ export interface TelegramChannelOpts {
 }
 
 /**
+ * Resolve the effective JID for an incoming message.
+ * If the message has a thread ID and that thread is registered as its own
+ * group, return the thread-scoped JID. Otherwise fall back to the base chat JID,
+ * which preserves the pre-threads behaviour of routing all thread messages
+ * into the parent chat group.
+ */
+export function resolveJid(
+  chatId: number | string,
+  threadId: number | undefined,
+  registeredGroups: Record<string, RegisteredGroup>,
+): string {
+  const baseJid = `tg:${chatId}`;
+  if (!threadId) return baseJid;
+  const threadJid = `tg:${chatId}:${threadId}`;
+  return registeredGroups[threadJid] ? threadJid : baseJid;
+}
+
+/**
+ * Build the /chatid reply text.
+ * In a thread, shows both the thread-scoped JID and the base chat JID.
+ */
+export function formatChatIdReply(
+  chatId: number | string,
+  threadId: number | undefined,
+  chatName: string,
+  chatType: string,
+  topicName?: string,
+): string {
+  const baseJid = `tg:${chatId}`;
+  const threadJid = threadId ? `tg:${chatId}:${threadId}` : null;
+
+  const lines = threadJid
+    ? [
+        `Thread ID: \`${threadJid}\`${topicName ? ` — ${topicName}` : ''} _(register to isolate this thread)_`,
+        `Chat ID: \`${baseJid}\` — ${chatName} _(register to include all threads)_`,
+        `Type: ${chatType}`,
+      ]
+    : [`Chat ID: \`${baseJid}\``, `Name: ${chatName}`, `Type: ${chatType}`];
+
+  return lines.join('\n');
+}
+
+/**
  * Send a message with Telegram Markdown parse mode, falling back to plain text.
  * Claude's output naturally matches Telegram's Markdown v1 format:
  *   *bold*, _italic_, `code`, ```code blocks```, [links](url)
@@ -47,6 +90,7 @@ export class TelegramChannel implements Channel {
   private bot: Bot | null = null;
   private opts: TelegramChannelOpts;
   private botToken: string;
+  private topicNames = new Map<string, string>(); // `${chatId}:${threadId}` → topic name
 
   constructor(botToken: string, opts: TelegramChannelOpts) {
     this.botToken = botToken;
@@ -60,6 +104,27 @@ export class TelegramChannel implements Channel {
       },
     });
 
+    // Cache forum topic names so thread registrations get a meaningful name
+    this.bot.on('message:forum_topic_created', (ctx) => {
+      const threadId = ctx.message.message_thread_id;
+      if (threadId) {
+        this.topicNames.set(
+          `${ctx.chat.id}:${threadId}`,
+          ctx.message.forum_topic_created.name,
+        );
+      }
+    });
+
+    this.bot.on('message:forum_topic_edited', (ctx) => {
+      const threadId = ctx.message.message_thread_id;
+      if (threadId && ctx.message.forum_topic_edited.name) {
+        this.topicNames.set(
+          `${ctx.chat.id}:${threadId}`,
+          ctx.message.forum_topic_edited.name,
+        );
+      }
+    });
+
     // Command to get chat ID (useful for registration)
     this.bot.command('chatid', (ctx) => {
       const chatId = ctx.chat.id;
@@ -68,16 +133,28 @@ export class TelegramChannel implements Channel {
         chatType === 'private'
           ? ctx.from?.first_name || 'Private'
           : (ctx.chat as any).title || 'Unknown';
-
+      const threadId = ctx.message?.message_thread_id;
+      const topicName = threadId
+        ? this.topicNames.get(`${chatId}:${threadId}`)
+        : undefined;
       ctx.reply(
-        `Chat ID: \`tg:${chatId}\`\nName: ${chatName}\nType: ${chatType}`,
-        { parse_mode: 'Markdown' },
+        formatChatIdReply(chatId, threadId, chatName, chatType, topicName),
+        {
+          parse_mode: 'Markdown',
+        },
       );
     });
 
     // Command to check bot status
     this.bot.command('ping', (ctx) => {
-      ctx.reply(`${ASSISTANT_NAME} is online.`);
+      const pingThreadId = ctx.message?.message_thread_id;
+      if (pingThreadId) {
+        ctx.reply(`${ASSISTANT_NAME} is online.`, {
+          message_thread_id: pingThreadId,
+        });
+      } else {
+        ctx.reply(`${ASSISTANT_NAME} is online.`);
+      }
     });
 
     // Telegram bot commands handled above — skip them in the general handler
@@ -90,7 +167,11 @@ export class TelegramChannel implements Channel {
         if (TELEGRAM_BOT_COMMANDS.has(cmd)) return;
       }
 
-      const chatJid = `tg:${ctx.chat.id}`;
+      const threadId = ctx.message.message_thread_id;
+      const baseJid = `tg:${ctx.chat.id}`;
+      const threadJid = threadId ? `tg:${ctx.chat.id}:${threadId}` : null;
+      const groups = this.opts.registeredGroups();
+      const chatJid = threadJid && groups[threadJid] ? threadJid : baseJid;
       let content = ctx.message.text;
       const timestamp = new Date(ctx.message.date * 1000).toISOString();
       const senderName =
@@ -100,13 +181,16 @@ export class TelegramChannel implements Channel {
         'Unknown';
       const sender = ctx.from?.id.toString() || '';
       const msgId = ctx.message.message_id.toString();
-      const threadId = ctx.message.message_thread_id;
 
-      // Determine chat name
+      // Determine chat name — for thread-scoped JIDs prefer the topic name
       const chatName =
         ctx.chat.type === 'private'
           ? senderName
-          : (ctx.chat as any).title || chatJid;
+          : (threadId &&
+              chatJid === threadJid &&
+              this.topicNames.get(`${ctx.chat.id}:${threadId}`)) ||
+            (ctx.chat as any).title ||
+            chatJid;
 
       // Translate Telegram @bot_username mentions into TRIGGER_PATTERN format.
       // Telegram @mentions (e.g., @andy_ai_bot) won't match TRIGGER_PATTERN
@@ -140,7 +224,7 @@ export class TelegramChannel implements Channel {
       );
 
       // Only deliver full message for registered groups
-      const group = this.opts.registeredGroups()[chatJid];
+      const group = groups[chatJid];
       if (!group) {
         logger.debug(
           { chatJid, chatName },
@@ -169,8 +253,12 @@ export class TelegramChannel implements Channel {
 
     // Handle non-text messages with placeholders so the agent knows something was sent
     const storeNonText = (ctx: any, placeholder: string) => {
-      const chatJid = `tg:${ctx.chat.id}`;
-      const group = this.opts.registeredGroups()[chatJid];
+      const threadId = ctx.message?.message_thread_id;
+      const baseJid = `tg:${ctx.chat.id}`;
+      const threadJid = threadId ? `tg:${ctx.chat.id}:${threadId}` : null;
+      const groups = this.opts.registeredGroups();
+      const chatJid = threadJid && groups[threadJid] ? threadJid : baseJid;
+      const group = groups[chatJid];
       if (!group) return;
 
       const timestamp = new Date(ctx.message.date * 1000).toISOString();
@@ -183,10 +271,14 @@ export class TelegramChannel implements Channel {
 
       const isGroup =
         ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+      const nonTextChatName =
+        threadId && chatJid === threadJid
+          ? this.topicNames.get(`${ctx.chat.id}:${threadId}`)
+          : undefined;
       this.opts.onChatMetadata(
         chatJid,
         timestamp,
-        undefined,
+        nonTextChatName,
         'telegram',
         isGroup,
       );
@@ -239,40 +331,33 @@ export class TelegramChannel implements Channel {
     });
   }
 
-  async sendMessage(
-    jid: string,
-    text: string,
-    threadId?: string,
-  ): Promise<void> {
+  async sendMessage(jid: string, text: string): Promise<void> {
     if (!this.bot) {
       logger.warn('Telegram bot not initialized');
       return;
     }
 
     try {
-      const numericId = jid.replace(/^tg:/, '');
-      const options = threadId
-        ? { message_thread_id: parseInt(threadId, 10) }
+      const [numericId, threadId] = jid.replace(/^tg:/, '').split(':');
+      const threadOptions = threadId
+        ? { message_thread_id: Number(threadId) }
         : {};
 
       // Telegram has a 4096 character limit per message — split if needed
       const MAX_LENGTH = 4096;
       if (text.length <= MAX_LENGTH) {
-        await sendTelegramMessage(this.bot.api, numericId, text, options);
+        await sendTelegramMessage(this.bot.api, numericId, text, threadOptions);
       } else {
         for (let i = 0; i < text.length; i += MAX_LENGTH) {
           await sendTelegramMessage(
             this.bot.api,
             numericId,
             text.slice(i, i + MAX_LENGTH),
-            options,
+            threadOptions,
           );
         }
       }
-      logger.info(
-        { jid, length: text.length, threadId },
-        'Telegram message sent',
-      );
+      logger.info({ jid, length: text.length }, 'Telegram message sent');
     } catch (err) {
       logger.error({ jid, err }, 'Failed to send Telegram message');
     }
@@ -297,8 +382,14 @@ export class TelegramChannel implements Channel {
   async setTyping(jid: string, isTyping: boolean): Promise<void> {
     if (!this.bot || !isTyping) return;
     try {
-      const numericId = jid.replace(/^tg:/, '');
-      await this.bot.api.sendChatAction(numericId, 'typing');
+      const [numericId, threadId] = jid.replace(/^tg:/, '').split(':');
+      if (threadId) {
+        await this.bot.api.sendChatAction(numericId, 'typing', {
+          message_thread_id: Number(threadId),
+        });
+      } else {
+        await this.bot.api.sendChatAction(numericId, 'typing');
+      }
     } catch (err) {
       logger.debug({ jid, err }, 'Failed to send Telegram typing indicator');
     }


### PR DESCRIPTION
## Summary

Adds the `add-telegram-threads-autoregistration` skill, which lets users opt in to automatically registering Telegram forum threads as isolated groups.

When applied, any new thread message in a registered supergroup is automatically registered as its own group — inheriting the parent's trigger, container config, and `requiresTrigger` setting — so each forum topic gets its own isolated context without manual registration.

## Depends on

Requires the forum thread support from PR #135. The `TelegramChannel` class must already have the `topicNames` map and `forum_topic_created`/`forum_topic_edited` listeners before this skill is applied.

## How it works

This is an instruction-only skill (no code on this branch). When a user runs `/add-telegram-threads-autoregistration`, Claude follows the SKILL.md to make the changes:

- Adds `registerGroup?` callback to `ChannelOpts` and `TelegramChannelOpts`
- Wires the existing `registerGroup` function from `index.ts` into channel opts
- Adds a private `autoRegisterThread` method to `TelegramChannel`
- Adds auto-register checks in both the text and non-text message handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)