### PR TITLE
feat: add voice message transcription for Telegram

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+TELEGRAM_BOT_TOKEN=
+
+# Voice transcription (optional) — set to enable voice message transcription
+OPENAI_API_KEY=

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -8,6 +8,11 @@ import { ASSISTANT_NAME, TRIGGER_PATTERN } from '../config.js';
 import { readEnvFile } from '../env.js';
 import { resolveGroupFolderPath } from '../group-folder.js';
 import { logger } from '../logger.js';
+import {
+  createWhisperProvider,
+  transcribeAudio,
+  type TranscriptionProvider,
+} from '../transcription.js';
 import { registerChannel, ChannelOpts } from './registry.js';
 import {
   Channel,
@@ -51,10 +56,16 @@ export class TelegramChannel implements Channel {
   private bot: Bot | null = null;
   private opts: TelegramChannelOpts;
   private botToken: string;
+  private transcriptionProvider: TranscriptionProvider | null;
 
-  constructor(botToken: string, opts: TelegramChannelOpts) {
+  constructor(
+    botToken: string,
+    opts: TelegramChannelOpts,
+    transcriptionProvider: TranscriptionProvider | null = null,
+  ) {
     this.botToken = botToken;
     this.opts = opts;
+    this.transcriptionProvider = transcriptionProvider;
   }
 
   /**
@@ -308,8 +319,29 @@ export class TelegramChannel implements Channel {
         filename: `video_${ctx.message.message_id}`,
       });
     });
-    this.bot.on('message:voice', (ctx) => {
-      storeMedia(ctx, '[Voice message]', {
+    this.bot.on('message:voice', async (ctx) => {
+      let placeholder = '[Voice message]';
+      if (this.transcriptionProvider) {
+        try {
+          const file = await ctx.getFile();
+          if (file.file_path) {
+            const url = `https://api.telegram.org/file/bot${this.botToken}/${file.file_path}`;
+            const res = await fetch(url);
+            if (res.ok) {
+              const buffer = Buffer.from(await res.arrayBuffer());
+              const text = await transcribeAudio(
+                this.transcriptionProvider,
+                buffer,
+                'audio/ogg',
+              );
+              if (text) placeholder = `[Voice: ${text}]`;
+            }
+          }
+        } catch (err) {
+          logger.debug({ err }, 'Voice download/transcription failed');
+        }
+      }
+      storeMedia(ctx, placeholder, {
         fileId: ctx.message.voice?.file_id,
         filename: `voice_${ctx.message.message_id}`,
       });
@@ -426,12 +458,15 @@ export class TelegramChannel implements Channel {
 }
 
 registerChannel('telegram', (opts: ChannelOpts) => {
-  const envVars = readEnvFile(['TELEGRAM_BOT_TOKEN']);
+  const envVars = readEnvFile(['TELEGRAM_BOT_TOKEN', 'OPENAI_API_KEY']);
   const token =
     process.env.TELEGRAM_BOT_TOKEN || envVars.TELEGRAM_BOT_TOKEN || '';
   if (!token) {
     logger.warn('Telegram: TELEGRAM_BOT_TOKEN not set');
     return null;
   }
-  return new TelegramChannel(token, opts);
+  const transcriber = envVars.OPENAI_API_KEY
+    ? createWhisperProvider(envVars.OPENAI_API_KEY)
+    : null;
+  return new TelegramChannel(token, opts, transcriber);
 });

--- a/src/transcription.test.ts
+++ b/src/transcription.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// --- Mocks ---
+
+const mockEnv: Record<string, string> = {};
+
+vi.mock('./env.js', () => ({
+  readEnvFile: vi.fn(() => ({ ...mockEnv })),
+}));
+
+vi.mock('./logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import {
+  createWhisperProvider,
+  createTranscriptionProvider,
+  transcribeAudio,
+  type TranscriptionProvider,
+} from './transcription.js';
+
+// --- Tests ---
+
+describe('createWhisperProvider', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sends correct request to OpenAI Whisper API', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve('Hello, this is a test.'),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const provider = createWhisperProvider('sk-test-key');
+    const result = await provider(Buffer.from('fake-audio'), 'audio/ogg');
+
+    expect(result).toBe('Hello, this is a test.');
+    expect(mockFetch).toHaveBeenCalledOnce();
+
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('https://api.openai.com/v1/audio/transcriptions');
+    expect(opts.method).toBe('POST');
+    expect(opts.headers.Authorization).toBe('Bearer sk-test-key');
+    expect(opts.body).toBeInstanceOf(FormData);
+  });
+
+  it('throws on non-ok response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: () => Promise.resolve('Unauthorized'),
+      }),
+    );
+
+    const provider = createWhisperProvider('sk-bad-key');
+    await expect(
+      provider(Buffer.from('fake-audio'), 'audio/ogg'),
+    ).rejects.toThrow('Whisper API 401: Unauthorized');
+  });
+});
+
+describe('createTranscriptionProvider', () => {
+  beforeEach(() => {
+    Object.keys(mockEnv).forEach((k) => delete mockEnv[k]);
+  });
+
+  it('returns null when no API key is set', () => {
+    const provider = createTranscriptionProvider();
+    expect(provider).toBeNull();
+  });
+
+  it('returns a provider when OPENAI_API_KEY is set', () => {
+    mockEnv.OPENAI_API_KEY = 'sk-test';
+    const provider = createTranscriptionProvider();
+    expect(provider).toBeTypeOf('function');
+  });
+});
+
+describe('transcribeAudio', () => {
+  it('returns null when provider is null', async () => {
+    const result = await transcribeAudio(null, Buffer.from('audio'), 'audio/ogg');
+    expect(result).toBeNull();
+  });
+
+  it('returns transcript on success', async () => {
+    const provider: TranscriptionProvider = vi
+      .fn()
+      .mockResolvedValue('transcribed text');
+    const result = await transcribeAudio(
+      provider,
+      Buffer.from('audio'),
+      'audio/ogg',
+    );
+    expect(result).toBe('transcribed text');
+  });
+
+  it('returns null on provider error', async () => {
+    const provider: TranscriptionProvider = vi
+      .fn()
+      .mockRejectedValue(new Error('API down'));
+    const result = await transcribeAudio(
+      provider,
+      Buffer.from('audio'),
+      'audio/ogg',
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/src/transcription.ts
+++ b/src/transcription.ts
@@ -1,0 +1,88 @@
+/**
+ * Voice message transcription module.
+ *
+ * Provides a provider-based interface for transcribing audio to text.
+ * Currently supports OpenAI Whisper API. Adding new providers (Groq,
+ * Deepgram, local whisper.cpp) requires only a new factory function.
+ *
+ * Similar to the voice transcription implementation in nanoclaw-whatsapp
+ * (see qwibitai/nanoclaw-whatsapp, branch skill/voice-transcription).
+ */
+import { readEnvFile } from './env.js';
+import { logger } from './logger.js';
+
+/**
+ * A transcription provider converts an audio buffer into text.
+ */
+export type TranscriptionProvider = (
+  audio: Buffer,
+  mimeType: string,
+) => Promise<string>;
+
+/**
+ * Create a provider that uses OpenAI's Whisper API.
+ */
+export function createWhisperProvider(apiKey: string): TranscriptionProvider {
+  return async (audio: Buffer, mimeType: string): Promise<string> => {
+    const ext = mimeType === 'audio/ogg' ? 'ogg' : 'wav';
+    const form = new FormData();
+    form.append(
+      'file',
+      new Blob([audio], { type: mimeType }),
+      `voice.${ext}`,
+    );
+    form.append('model', 'whisper-1');
+    form.append('response_format', 'text');
+
+    const res = await fetch(
+      'https://api.openai.com/v1/audio/transcriptions',
+      {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${apiKey}` },
+        body: form,
+      },
+    );
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`Whisper API ${res.status}: ${body}`);
+    }
+
+    return (await res.text()).trim();
+  };
+}
+
+/**
+ * Create a transcription provider based on available environment variables.
+ * Returns null if no provider can be configured (voice transcription disabled).
+ */
+export function createTranscriptionProvider(): TranscriptionProvider | null {
+  const env = readEnvFile(['OPENAI_API_KEY']);
+  const key = env.OPENAI_API_KEY;
+  if (!key) {
+    logger.debug('No OPENAI_API_KEY — voice transcription disabled');
+    return null;
+  }
+  logger.info('Voice transcription enabled (OpenAI Whisper)');
+  return createWhisperProvider(key);
+}
+
+/**
+ * Transcribe audio using the given provider. Returns the transcript text,
+ * or null if the provider is null or transcription fails for any reason.
+ */
+export async function transcribeAudio(
+  provider: TranscriptionProvider | null,
+  audio: Buffer,
+  mimeType: string,
+): Promise<string | null> {
+  if (!provider) return null;
+  try {
+    const text = await provider(audio, mimeType);
+    logger.info({ length: text.length }, 'Transcribed voice message');
+    return text;
+  } catch (err) {
+    logger.debug({ err }, 'Transcription failed, falling back to placeholder');
+    return null;
+  }
+}


### PR DESCRIPTION
## Type of Change

- [x] **Feature** - new functionality in source code

## Description

Adds voice message transcription to the Telegram channel using OpenAI's Whisper API. When `OPENAI_API_KEY` is set, voice messages are downloaded from Telegram, transcribed, and delivered to agents as `[Voice: <transcript>]`. Falls back silently to `[Voice message]` if no key is configured or transcription fails.

### What changed

- **`src/transcription.ts`** — Provider-based transcription module. Supports OpenAI Whisper via raw `fetch` (no `openai` npm dependency).
- **`src/transcription.test.ts`** — 7 unit tests for the transcription module.
- **`src/channels/telegram.ts`** — Voice handler downloads audio via Telegram Bot API, transcribes via provider.
- **env example file** — Added `OPENAI_API_KEY` (optional)

> **Note for maintainer:** This PR should be retargeted to a new `skill/voice-transcription` branch (not merged into `main`). The companion skill definition is in PR #120, which adds the `/add-voice-transcription` skill to `main` that merges from this branch.

## Test plan

- [x] `npm run build` — no type errors
- [x] `npx vitest run src/transcription.test.ts` — 7 tests passing
- [x] `npx vitest run src/channels/telegram.test.ts` — 50 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
