### PR TITLE
feat: pass Telegram reply/quoted message context to agent

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -102,6 +102,14 @@ export class TelegramChannel implements Channel {
       const msgId = ctx.message.message_id.toString();
       const threadId = ctx.message.message_thread_id;
 
+      const replyTo = ctx.message.reply_to_message;
+      const replyToMessageId = replyTo?.message_id?.toString();
+      const replyToContent = replyTo?.text || replyTo?.caption;
+      const replyToSenderName =
+        replyTo?.from?.first_name ||
+        replyTo?.from?.username ||
+        replyTo?.from?.id?.toString();
+
       // Determine chat name
       const chatName =
         ctx.chat.type === 'private'
@@ -159,6 +167,9 @@ export class TelegramChannel implements Channel {
         timestamp,
         is_from_me: false,
         thread_id: threadId ? threadId.toString() : undefined,
+        reply_to_message_id: replyToMessageId,
+        reply_to_message_content: replyToContent,
+        reply_to_sender_name: replyToSenderName,
       });
 
       logger.info(

--- a/src/router.ts
+++ b/src/router.ts
@@ -16,7 +16,14 @@ export function formatMessages(
 ): string {
   const lines = messages.map((m) => {
     const displayTime = formatLocalTime(m.timestamp, timezone);
-    return `<message sender="${escapeXml(m.sender_name)}" time="${escapeXml(displayTime)}">${escapeXml(m.content)}</message>`;
+    const replyAttr = m.reply_to_message_id
+      ? ` reply_to="${escapeXml(m.reply_to_message_id)}"`
+      : '';
+    const replySnippet =
+      m.reply_to_message_content && m.reply_to_sender_name
+        ? `\n  <quoted_message from="${escapeXml(m.reply_to_sender_name)}">${escapeXml(m.reply_to_message_content)}</quoted_message>`
+        : '';
+    return `<message sender="${escapeXml(m.sender_name)}" time="${escapeXml(displayTime)}"${replyAttr}>${replySnippet}${escapeXml(m.content)}</message>`;
   });
 
   const header = `<context timezone="${escapeXml(timezone)}" />\n`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,9 @@ export interface NewMessage {
   is_from_me?: boolean;
   is_bot_message?: boolean;
   thread_id?: string;
+  reply_to_message_id?: string;
+  reply_to_message_content?: string;
+  reply_to_sender_name?: string;
 }
 
 export interface ScheduledTask {


### PR DESCRIPTION
## Summary

When a Telegram user replies to a message, NanoClaw now captures and forwards that quoted context to the agent. Previously the agent had no visibility into what message was being replied to.

### Changes

- **`src/types.ts`**: Added three optional fields to the `NewMessage` interface:
  - `reply_to_message_id?: string`
  - `reply_to_message_content?: string`
  - `reply_to_sender_name?: string`

- **`src/channels/telegram.ts`**: In the `message:text` handler, extracts `reply_to_message` from the Telegram context and maps it to the three new fields on the `onMessage` call.

- **`src/router.ts`**: Updated `formatMessages` to render reply context in the XML prompt:
  - Adds a `reply_to` attribute on `<message>` when a reply ID is present
  - Inlines a `<quoted_message from="...">` child element with the original message text and sender name

### Result

The agent now sees something like:

```xml
<message sender="Leon" time="10:32" reply_to="12345">
  <quoted_message from="Sasha">Are you coming tonight?</quoted_message>
  Yes, on my way!
</message>
```

This makes conversational threading much more coherent in group chats.
