### PR TITLE
feat: add inbound image vision for Telegram photos

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -29,6 +29,7 @@ interface ContainerInput {
   isScheduledTask?: boolean;
   assistantName?: string;
   script?: string;
+  imageAttachments?: Array<{ relativePath: string; mediaType: string }>;
 }
 
 interface ContainerOutput {
@@ -73,6 +74,16 @@ class MessageStream {
     this.queue.push({
       type: 'user',
       message: { role: 'user', content: text },
+      parent_tool_use_id: null,
+      session_id: '',
+    });
+    this.waiting?.();
+  }
+
+  pushMultimodal(blocks: Array<{ type: 'image'; source: { type: 'base64'; media_type: string; data: string } }>): void {
+    this.queue.push({
+      type: 'user',
+      message: { role: 'user', content: blocks as any },
       parent_tool_use_id: null,
       session_id: '',
     });
@@ -341,6 +352,33 @@ async function runQuery(
 ): Promise<{ newSessionId?: string; lastAssistantUuid?: string; closedDuringQuery: boolean }> {
   const stream = new MessageStream();
   stream.push(prompt);
+
+  // Load image attachments as multimodal content blocks
+  const ALLOWED_MEDIA_TYPES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
+  if (containerInput.imageAttachments?.length) {
+    const blocks: Array<{ type: 'image'; source: { type: 'base64'; media_type: string; data: string } }> = [];
+    for (const img of containerInput.imageAttachments) {
+      // Security: confine path to /workspace/group/attachments/
+      const imgPath = path.resolve('/workspace/group', img.relativePath);
+      if (!imgPath.startsWith('/workspace/group/attachments/')) {
+        log(`Skipping image outside attachments dir: ${img.relativePath}`);
+        continue;
+      }
+      if (!ALLOWED_MEDIA_TYPES.has(img.mediaType)) {
+        log(`Skipping image with unsupported media type: ${img.mediaType}`);
+        continue;
+      }
+      try {
+        const data = fs.readFileSync(imgPath).toString('base64');
+        blocks.push({ type: 'image', source: { type: 'base64', media_type: img.mediaType, data } });
+      } catch (err) {
+        log(`Failed to load image: ${imgPath}`);
+      }
+    }
+    if (blocks.length > 0) {
+      stream.pushMultimodal(blocks);
+    }
+  }
 
   // Poll IPC for follow-up messages and _close sentinel during the query
   let ipcPolling = true;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "@onecli-sh/sdk": "^0.2.0",
     "better-sqlite3": "11.10.0",
     "cron-parser": "5.5.0",
-    "grammy": "^1.39.3"
+    "grammy": "^1.39.3",
+    "sharp": "^0.34.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -1,7 +1,9 @@
 import https from 'https';
+import path from 'path';
 import { Api, Bot } from 'grammy';
 
-import { ASSISTANT_NAME, TRIGGER_PATTERN } from '../config.js';
+import { ASSISTANT_NAME, GROUPS_DIR, TRIGGER_PATTERN } from '../config.js';
+import { processImage } from '../image.js';
 import { readEnvFile } from '../env.js';
 import { logger } from '../logger.js';
 import { registerChannel, ChannelOpts } from './registry.js';
@@ -201,7 +203,59 @@ export class TelegramChannel implements Channel {
       });
     };
 
-    this.bot.on('message:photo', (ctx) => storeNonText(ctx, '[Photo]'));
+    this.bot.on('message:photo', async (ctx) => {
+      const chatJid = `tg:${ctx.chat.id}`;
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) return;
+
+      try {
+        // Pick the largest available size
+        const photos = ctx.message.photo;
+        const largest = photos[photos.length - 1];
+        const fileInfo = await ctx.api.getFile(largest.file_id);
+        const filePath = fileInfo.file_path;
+        if (!filePath) throw new Error('Empty file_path from Telegram');
+
+        // Validate file_path before constructing URL (defense in depth)
+        if (filePath.includes('://') || filePath.includes('..')) {
+          throw new Error(`Unexpected file_path format: ${filePath}`);
+        }
+        const url = `https://api.telegram.org/file/bot${this.botToken}/${filePath}`;
+
+        const resp = await fetch(url);
+        if (!resp.ok) throw new Error(`Download failed: ${resp.status}`);
+        const buffer = Buffer.from(await resp.arrayBuffer());
+
+        const groupDir = path.join(GROUPS_DIR, group.folder);
+        const caption = ctx.message.caption || '';
+        const processed = await processImage(buffer, groupDir, caption);
+
+        if (processed) {
+          const timestamp = new Date(ctx.message.date * 1000).toISOString();
+          const senderName =
+            ctx.from?.first_name ||
+            ctx.from?.username ||
+            ctx.from?.id?.toString() ||
+            'Unknown';
+          const isGroup =
+            ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+          this.opts.onChatMetadata(chatJid, timestamp, undefined, 'telegram', isGroup);
+          this.opts.onMessage(chatJid, {
+            id: ctx.message.message_id.toString(),
+            chat_jid: chatJid,
+            sender: ctx.from?.id?.toString() || '',
+            sender_name: senderName,
+            content: processed.content,
+            timestamp,
+            is_from_me: false,
+          });
+          logger.info({ chatJid, path: processed.relativePath }, 'Processed image attachment');
+        }
+      } catch (err) {
+        logger.error({ chatJid, err }, 'Image download/processing failed');
+        storeNonText(ctx, '[Photo]');
+      }
+    });
     this.bot.on('message:video', (ctx) => storeNonText(ctx, '[Video]'));
     this.bot.on('message:voice', (ctx) => storeNonText(ctx, '[Voice message]'));
     this.bot.on('message:audio', (ctx) => storeNonText(ctx, '[Audio]'));

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -43,6 +43,7 @@ export interface ContainerInput {
   isScheduledTask?: boolean;
   assistantName?: string;
   script?: string;
+  imageAttachments?: Array<{ relativePath: string; mediaType: string }>;
 }
 
 export interface ContainerOutput {

--- a/src/image.ts
+++ b/src/image.ts
@@ -1,0 +1,61 @@
+import fs from 'fs';
+import path from 'path';
+import sharp from 'sharp';
+
+const MAX_DIMENSION = 1024;
+const IMAGE_REF_PATTERN = /\[Image: (attachments\/[^\]]+)\]/g;
+
+export interface ProcessedImage {
+  content: string;
+  relativePath: string;
+}
+
+export interface ImageAttachment {
+  relativePath: string;
+  mediaType: string;
+}
+
+export async function processImage(
+  buffer: Buffer,
+  groupDir: string,
+  caption: string,
+): Promise<ProcessedImage | null> {
+  if (!buffer || buffer.length === 0) return null;
+
+  const resized = await sharp(buffer)
+    .resize(MAX_DIMENSION, MAX_DIMENSION, {
+      fit: 'inside',
+      withoutEnlargement: true,
+    })
+    .jpeg({ quality: 85 })
+    .toBuffer();
+
+  const attachDir = path.join(groupDir, 'attachments');
+  fs.mkdirSync(attachDir, { recursive: true });
+
+  const filename = `img-${Date.now()}-${Math.random().toString(36).slice(2, 6)}.jpg`;
+  const filePath = path.join(attachDir, filename);
+  fs.writeFileSync(filePath, resized);
+
+  const relativePath = `attachments/${filename}`;
+  const content = caption
+    ? `[Image: ${relativePath}] ${caption}`
+    : `[Image: ${relativePath}]`;
+
+  return { content, relativePath };
+}
+
+export function parseImageReferences(
+  messages: Array<{ content: string }>,
+): ImageAttachment[] {
+  const refs: ImageAttachment[] = [];
+  for (const msg of messages) {
+    let match: RegExpExecArray | null;
+    IMAGE_REF_PATTERN.lastIndex = 0;
+    while ((match = IMAGE_REF_PATTERN.exec(msg.content)) !== null) {
+      // Always JPEG — processImage() normalizes all images to .jpg
+      refs.push({ relativePath: match[1], mediaType: 'image/jpeg' });
+    }
+  }
+  return refs;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import {
   writeGroupsSnapshot,
   writeTasksSnapshot,
 } from './container-runner.js';
+import { parseImageReferences } from './image.js';
 import {
   cleanupOrphans,
   ensureContainerRuntimeRunning,
@@ -250,6 +251,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   }
 
   const prompt = formatMessages(missedMessages, TIMEZONE);
+  const imageAttachments = parseImageReferences(missedMessages);
 
   // Advance cursor so the piping path in startMessageLoop won't re-fetch
   // these messages. Save the old cursor so we can roll back on error.
@@ -281,7 +283,7 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   let hadError = false;
   let outputSentToUser = false;
 
-  const output = await runAgent(group, prompt, chatJid, async (result) => {
+  const output = await runAgent(group, prompt, chatJid, imageAttachments, async (result) => {
     // Streaming output callback — called for each agent result
     if (result.result) {
       const raw =
@@ -338,6 +340,7 @@ async function runAgent(
   group: RegisteredGroup,
   prompt: string,
   chatJid: string,
+  imageAttachments: Array<{ relativePath: string; mediaType: string }>,
   onOutput?: (output: ContainerOutput) => Promise<void>,
 ): Promise<'success' | 'error'> {
   const isMain = group.isMain === true;
@@ -390,6 +393,7 @@ async function runAgent(
         chatJid,
         isMain,
         assistantName: ASSISTANT_NAME,
+        ...(imageAttachments.length > 0 && { imageAttachments }),
       },
       (proc, containerName) =>
         queue.registerProcess(chatJid, proc, containerName, group.folder),


### PR DESCRIPTION
## What

Adds image vision for Telegram — photos sent to the bot are downloaded, resized, and passed to Claude as multimodal content blocks so the agent can see and understand image content.

## Why

PR #9 covers this but includes outbound `sendImage` with path traversal vulnerabilities (absolute paths from container agents passed verbatim to host `sendImage`, enabling host filesystem exfiltration). This PR delivers inbound vision only, with security fixes applied.

## How it works

1. `message:photo` handler downloads the largest available photo from Telegram's file API
2. `sharp` resizes to max 1024px, converts to JPEG at quality 85, saves to `groups/{folder}/attachments/`
3. Message content becomes `[Image: attachments/img-{ts}-{rand}.jpg]`
4. `parseImageReferences()` extracts refs from messages before each agent run
5. Agent-runner reads the files and pushes them as multimodal content blocks to Claude

## Security vs PR #9

- **Path confinement**: `path.resolve()` + prefix check ensures image paths stay within `/workspace/group/attachments/` before `readFileSync` (fixes audit Finding 3)
- **Media type allowlist**: only `image/jpeg`, `image/png`, `image/gif`, `image/webp` accepted before passing to Claude API (fixes Finding 6)
- **file_path validation**: Telegram's `file_path` validated to not contain `://` or `..` before URL construction (fixes Finding 5)
- **No sendImage / no IPC send_image**: outbound image sending excluded entirely, eliminating the Critical path traversal findings (1, 2, 4) from the audit

## How it was tested

Tested on a live NanoClaw + Telegram instance. Sent a photo in a registered Telegram group — agent correctly described the image content.

## Type of change

- [x] Source code change