### PR TITLE
feat: pass reply/quoted message context to agent (with DB persistence)

### DIFF
--- a/src/channels/telegram.test.ts
+++ b/src/channels/telegram.test.ts
@@ -110,6 +110,7 @@ function createTextCtx(overrides: {
   messageId?: number;
   date?: number;
   entities?: any[];
+  reply_to_message?: any;
 }) {
   const chatId = overrides.chatId ?? 100200300;
   const chatType = overrides.chatType ?? 'group';
@@ -129,6 +130,7 @@ function createTextCtx(overrides: {
       date: overrides.date ?? Math.floor(Date.now() / 1000),
       message_id: overrides.messageId ?? 1,
       entities: overrides.entities ?? [],
+      reply_to_message: overrides.reply_to_message,
     },
     me: { username: 'andy_ai_bot' },
     reply: vi.fn(),
@@ -568,6 +570,100 @@ describe('TelegramChannel', () => {
         'tg:100200300',
         expect.objectContaining({
           content: 'check https://example.com',
+        }),
+      );
+    });
+  });
+
+  // --- Reply context ---
+
+  describe('reply context', () => {
+    it('extracts reply_to fields when replying to a text message', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'Yes, on my way!',
+        reply_to_message: {
+          message_id: 42,
+          text: 'Are you coming tonight?',
+          from: { id: 777, first_name: 'Bob', username: 'bob_user' },
+        },
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          content: 'Yes, on my way!',
+          reply_to_message_id: '42',
+          reply_to_message_content: 'Are you coming tonight?',
+          reply_to_sender_name: 'Bob',
+        }),
+      );
+    });
+
+    it('uses caption when reply has no text (media reply)', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'Nice photo!',
+        reply_to_message: {
+          message_id: 50,
+          caption: 'Check this out',
+          from: { id: 888, first_name: 'Carol' },
+        },
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          reply_to_message_content: 'Check this out',
+        }),
+      );
+    });
+
+    it('falls back to Unknown when reply sender has no from', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({
+        text: 'Interesting',
+        reply_to_message: {
+          message_id: 60,
+          text: 'Channel post',
+        },
+      });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          reply_to_message_id: '60',
+          reply_to_sender_name: 'Unknown',
+        }),
+      );
+    });
+
+    it('does not set reply fields when no reply_to_message', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const ctx = createTextCtx({ text: 'Just a normal message' });
+      await triggerTextMessage(ctx);
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'tg:100200300',
+        expect.objectContaining({
+          reply_to_message_id: undefined,
+          reply_to_message_content: undefined,
+          reply_to_sender_name: undefined,
         }),
       );
     });

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -102,6 +102,14 @@ export class TelegramChannel implements Channel {
       const msgId = ctx.message.message_id.toString();
       const threadId = ctx.message.message_thread_id;
 
+      const replyTo = ctx.message.reply_to_message;
+      const replyToMessageId = replyTo?.message_id?.toString();
+      const replyToContent = replyTo?.text || replyTo?.caption;
+      const replyToSenderName =
+        replyTo?.from?.first_name ||
+        replyTo?.from?.username ||
+        replyTo?.from?.id?.toString();
+
       // Determine chat name
       const chatName =
         ctx.chat.type === 'private'
@@ -159,6 +167,9 @@ export class TelegramChannel implements Channel {
         timestamp,
         is_from_me: false,
         thread_id: threadId ? threadId.toString() : undefined,
+        reply_to_message_id: replyToMessageId,
+        reply_to_message_content: replyToContent,
+        reply_to_sender_name: replyToSenderName,
       });
 
       logger.info(

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -157,10 +157,12 @@ export class TelegramChannel implements Channel {
       const replyTo = ctx.message.reply_to_message;
       const replyToMessageId = replyTo?.message_id?.toString();
       const replyToContent = replyTo?.text || replyTo?.caption;
-      const replyToSenderName =
-        replyTo?.from?.first_name ||
-        replyTo?.from?.username ||
-        replyTo?.from?.id?.toString();
+      const replyToSenderName = replyTo
+        ? replyTo.from?.first_name ||
+          replyTo.from?.username ||
+          replyTo.from?.id?.toString() ||
+          'Unknown'
+        : undefined;
 
       // Determine chat name
       const chatName =

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -142,6 +142,86 @@ describe('storeMessage', () => {
   });
 });
 
+// --- reply context persistence ---
+
+describe('reply context', () => {
+  it('stores and retrieves reply_to fields', () => {
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:00.000Z');
+
+    storeMessage({
+      id: 'reply-1',
+      chat_jid: 'group@g.us',
+      sender: '123',
+      sender_name: 'Alice',
+      content: 'Yes, on my way!',
+      timestamp: '2024-01-01T00:00:01.000Z',
+      reply_to_message_id: '42',
+      reply_to_message_content: 'Are you coming tonight?',
+      reply_to_sender_name: 'Bob',
+    });
+
+    const messages = getMessagesSince(
+      'group@g.us',
+      '2024-01-01T00:00:00.000Z',
+      'Andy',
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].reply_to_message_id).toBe('42');
+    expect(messages[0].reply_to_message_content).toBe(
+      'Are you coming tonight?',
+    );
+    expect(messages[0].reply_to_sender_name).toBe('Bob');
+  });
+
+  it('returns null for messages without reply context', () => {
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:00.000Z');
+
+    store({
+      id: 'no-reply',
+      chat_jid: 'group@g.us',
+      sender: '123',
+      sender_name: 'Alice',
+      content: 'Just a normal message',
+      timestamp: '2024-01-01T00:00:01.000Z',
+    });
+
+    const messages = getMessagesSince(
+      'group@g.us',
+      '2024-01-01T00:00:00.000Z',
+      'Andy',
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].reply_to_message_id).toBeNull();
+    expect(messages[0].reply_to_message_content).toBeNull();
+    expect(messages[0].reply_to_sender_name).toBeNull();
+  });
+
+  it('retrieves reply context via getNewMessages', () => {
+    storeChatMetadata('group@g.us', '2024-01-01T00:00:00.000Z');
+
+    storeMessage({
+      id: 'reply-2',
+      chat_jid: 'group@g.us',
+      sender: '456',
+      sender_name: 'Carol',
+      content: 'Agreed',
+      timestamp: '2024-01-01T00:00:01.000Z',
+      reply_to_message_id: '99',
+      reply_to_message_content: 'We should meet',
+      reply_to_sender_name: 'Dave',
+    });
+
+    const { messages } = getNewMessages(
+      ['group@g.us'],
+      '2024-01-01T00:00:00.000Z',
+      'Andy',
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].reply_to_message_id).toBe('99');
+    expect(messages[0].reply_to_sender_name).toBe('Dave');
+  });
+});
+
 // --- getMessagesSince ---
 
 describe('getMessagesSince', () => {

--- a/src/db.ts
+++ b/src/db.ts
@@ -146,6 +146,21 @@ function createSchema(database: Database.Database): void {
   } catch {
     /* columns already exist */
   }
+
+  // Add reply context columns if they don't exist (migration for existing DBs)
+  try {
+    database.exec(
+      `ALTER TABLE messages ADD COLUMN reply_to_message_id TEXT`,
+    );
+    database.exec(
+      `ALTER TABLE messages ADD COLUMN reply_to_message_content TEXT`,
+    );
+    database.exec(
+      `ALTER TABLE messages ADD COLUMN reply_to_sender_name TEXT`,
+    );
+  } catch {
+    /* columns already exist */
+  }
 }
 
 export function initDatabase(): void {
@@ -274,7 +289,7 @@ export function setLastGroupSync(): void {
  */
 export function storeMessage(msg: NewMessage): void {
   db.prepare(
-    `INSERT OR REPLACE INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me, is_bot_message) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT OR REPLACE INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me, is_bot_message, reply_to_message_id, reply_to_message_content, reply_to_sender_name) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     msg.id,
     msg.chat_jid,
@@ -284,6 +299,9 @@ export function storeMessage(msg: NewMessage): void {
     msg.timestamp,
     msg.is_from_me ? 1 : 0,
     msg.is_bot_message ? 1 : 0,
+    msg.reply_to_message_id ?? null,
+    msg.reply_to_message_content ?? null,
+    msg.reply_to_sender_name ?? null,
   );
 }
 
@@ -328,7 +346,8 @@ export function getNewMessages(
   // Subquery takes the N most recent, outer query re-sorts chronologically.
   const sql = `
     SELECT * FROM (
-      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me
+      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me,
+             reply_to_message_id, reply_to_message_content, reply_to_sender_name
       FROM messages
       WHERE timestamp > ? AND chat_jid IN (${placeholders})
         AND is_bot_message = 0 AND content NOT LIKE ?
@@ -361,7 +380,8 @@ export function getMessagesSince(
   // Subquery takes the N most recent, outer query re-sorts chronologically.
   const sql = `
     SELECT * FROM (
-      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me
+      SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me,
+             reply_to_message_id, reply_to_message_content, reply_to_sender_name
       FROM messages
       WHERE chat_jid = ? AND timestamp > ?
         AND is_bot_message = 0 AND content NOT LIKE ?

--- a/src/formatting.test.ts
+++ b/src/formatting.test.ts
@@ -115,6 +115,62 @@ describe('formatMessages', () => {
     expect(result).toContain('<messages>\n\n</messages>');
   });
 
+  it('renders reply context as quoted_message element', () => {
+    const result = formatMessages(
+      [
+        makeMsg({
+          content: 'Yes, on my way!',
+          reply_to_message_id: '42',
+          reply_to_message_content: 'Are you coming tonight?',
+          reply_to_sender_name: 'Bob',
+        }),
+      ],
+      TZ,
+    );
+    expect(result).toContain('reply_to="42"');
+    expect(result).toContain(
+      '<quoted_message from="Bob">Are you coming tonight?</quoted_message>',
+    );
+    expect(result).toContain('Yes, on my way!</message>');
+  });
+
+  it('omits reply attributes when no reply context', () => {
+    const result = formatMessages([makeMsg()], TZ);
+    expect(result).not.toContain('reply_to');
+    expect(result).not.toContain('quoted_message');
+  });
+
+  it('omits quoted_message when content is missing but id is present', () => {
+    const result = formatMessages(
+      [
+        makeMsg({
+          reply_to_message_id: '42',
+          reply_to_sender_name: 'Bob',
+        }),
+      ],
+      TZ,
+    );
+    expect(result).toContain('reply_to="42"');
+    expect(result).not.toContain('quoted_message');
+  });
+
+  it('escapes special characters in reply context', () => {
+    const result = formatMessages(
+      [
+        makeMsg({
+          reply_to_message_id: '1',
+          reply_to_message_content: '<script>alert("xss")</script>',
+          reply_to_sender_name: 'A & B',
+        }),
+      ],
+      TZ,
+    );
+    expect(result).toContain('from="A &amp; B"');
+    expect(result).toContain(
+      '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;',
+    );
+  });
+
   it('converts timestamps to local time for given timezone', () => {
     // 2024-01-01T18:30:00Z in America/New_York (EST) = 1:30 PM
     const result = formatMessages(

--- a/src/router.ts
+++ b/src/router.ts
@@ -16,7 +16,14 @@ export function formatMessages(
 ): string {
   const lines = messages.map((m) => {
     const displayTime = formatLocalTime(m.timestamp, timezone);
-    return `<message sender="${escapeXml(m.sender_name)}" time="${escapeXml(displayTime)}">${escapeXml(m.content)}</message>`;
+    const replyAttr = m.reply_to_message_id
+      ? ` reply_to="${escapeXml(m.reply_to_message_id)}"`
+      : '';
+    const replySnippet =
+      m.reply_to_message_content && m.reply_to_sender_name
+        ? `\n  <quoted_message from="${escapeXml(m.reply_to_sender_name)}">${escapeXml(m.reply_to_message_content)}</quoted_message>`
+        : '';
+    return `<message sender="${escapeXml(m.sender_name)}" time="${escapeXml(displayTime)}"${replyAttr}>${replySnippet}${escapeXml(m.content)}</message>`;
   });
 
   const header = `<context timezone="${escapeXml(timezone)}" />\n`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,9 @@ export interface NewMessage {
   is_from_me?: boolean;
   is_bot_message?: boolean;
   thread_id?: string;
+  reply_to_message_id?: string;
+  reply_to_message_content?: string;
+  reply_to_sender_name?: string;
 }
 
 export interface ScheduledTask {


### PR DESCRIPTION
## Summary

Based on #139 by @leonalfredbot-ship-it — adds reply/quoted message context support for Telegram, with the following additions:

- **DB migration**: adds `reply_to_message_id`, `reply_to_message_content`, `reply_to_sender_name` columns to the `messages` table so reply context survives restarts and history re-reads
- **storeMessage / getMessagesSince / getNewMessages**: updated to persist and retrieve reply fields
- **Sender fallback**: falls back to `'Unknown'` when the replied-to message has no `from` (anonymous admins, channel posts)
- **11 new tests**: DB round-trip (3), XML formatting (4), Telegram extraction (4)

Closes #139

## Test plan

- [x] 301/301 tests pass
- [x] Type-checks cleanly (`tsc --noEmit`)
- [ ] Manual test: reply to a message in Telegram, verify agent sees `<quoted_message>` in context

🤖 Generated with [Claude Code](https://claude.com/claude-code)