### PR TITLE
feat(image-vision): add multimodal image vision for Telegram

### DIFF
--- a/.claude/skills/add-image-vision/SKILL.md
+++ b/.claude/skills/add-image-vision/SKILL.md
@@ -1,22 +1,64 @@
 ---
 name: add-image-vision
-description: Add image vision to NanoClaw agents. Resizes and processes WhatsApp image attachments, then sends them to Claude as multimodal content blocks.
+description: Add image vision to NanoClaw agents. Images arriving via supported channels are downloaded, resized with sharp, and sent to Claude as multimodal content blocks so the agent sees them directly instead of just a file path.
 ---
 
 # Image Vision Skill
 
-Adds the ability for NanoClaw agents to see and understand images sent via WhatsApp. Images are downloaded, resized with sharp, saved to the group workspace, and passed to the agent as base64-encoded multimodal content blocks.
+Adds the ability for NanoClaw agents to see and understand images sent via supported channels. Images are downloaded, resized with sharp (<=1024px, JPEG q85), saved to the group workspace, and passed to the agent as base64-encoded multimodal content blocks.
+
+**Supported channels:**
+- **Telegram** — native support via `nanoclaw-telegram` (merge `telegram/skill/image-vision`)
+- **WhatsApp** — native support via `nanoclaw-whatsapp` (merge `whatsapp/skill/image-vision`)
+
+Both channels share the same channel-agnostic `src/image.ts` module and the same multimodal handling in the agent-runner. Adding image-vision to a new channel means writing ~30 lines in that channel's photo/image handler to call `processImageFile()` and emit the `[Image: attachments/...]` marker — the core pipeline is channel-independent.
 
 ## Phase 1: Pre-flight
 
 1. Check if `src/image.ts` exists — skip to Phase 3 if already applied
 2. Confirm `sharp` is installable (native bindings require build tools)
+3. Identify which channel you're adding vision to — Telegram or WhatsApp — and use the matching skill branch below
 
-**Prerequisite:** WhatsApp must be installed first (`skill/whatsapp` merged). This skill modifies WhatsApp channel files.
+**Prerequisite:** The matching channel must be installed first. Image-vision modifies channel-specific files (e.g. `src/channels/telegram.ts` or `src/channels/whatsapp.ts`).
 
 ## Phase 2: Apply Code Changes
 
-### Ensure WhatsApp fork remote
+### For Telegram
+
+Ensure the telegram remote is present:
+
+```bash
+git remote -v
+```
+
+If `telegram` is missing, add it:
+
+```bash
+git remote add telegram https://github.com/qwibitai/nanoclaw-telegram.git
+```
+
+Merge the skill branch:
+
+```bash
+git fetch telegram skill/image-vision
+git merge telegram/skill/image-vision || {
+  git checkout --theirs package-lock.json
+  git add package-lock.json
+  git merge --continue
+}
+```
+
+This merges in:
+- `src/image.ts` (channel-agnostic: download, resize via sharp, base64 encoding, `parseImageReferences()`)
+- Image attachment handling in `src/channels/telegram.ts` (new photo handler that calls `processImageFile()`)
+- Updated `src/channels/telegram.test.ts` (mocks image.js, asserts new marker)
+- Image passing to agent in `src/index.ts` (parseImageReferences call) and `src/container-runner.ts` (ContainerInput.imageAttachments)
+- Image content block support in `container/agent-runner/src/index.ts` (types, MessageStream.pushMultimodal, runQuery loader)
+- `sharp` npm dependency in `package.json`
+
+### For WhatsApp
+
+Ensure the whatsapp remote is present:
 
 ```bash
 git remote -v
@@ -28,7 +70,7 @@ If `whatsapp` is missing, add it:
 git remote add whatsapp https://github.com/qwibitai/nanoclaw-whatsapp.git
 ```
 
-### Merge the skill branch
+Merge the skill branch:
 
 ```bash
 git fetch whatsapp skill/image-vision
@@ -39,15 +81,11 @@ git merge whatsapp/skill/image-vision || {
 }
 ```
 
-This merges in:
-- `src/image.ts` (image download, resize via sharp, base64 encoding)
-- `src/image.test.ts` (8 unit tests)
-- Image attachment handling in `src/channels/whatsapp.ts`
-- Image passing to agent in `src/index.ts` and `src/container-runner.ts`
-- Image content block support in `container/agent-runner/src/index.ts`
-- `sharp` npm dependency in `package.json`
+This merges in the whatsapp-specific channel handler and the same underlying `src/image.ts` pipeline. If you have both telegram and whatsapp installed, both photo handlers use the same `src/image.ts` module — so merging both skill branches is fine and the shared files resolve cleanly (or produce trivial conflicts you take from whichever side matches your working tree).
 
-If the merge reports conflicts, resolve them by reading the conflicted files and understanding the intent of both sides.
+### In either case
+
+If the merge reports conflicts, resolve them by reading the conflicted files and understanding the intent of both sides. The sharp dependency and the core multimodal infrastructure are identical between the two skill branches; only the channel-specific photo handler file differs.
 
 ### Validate code changes
 

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -33,7 +33,22 @@ interface ContainerInput {
   isScheduledTask?: boolean;
   assistantName?: string;
   script?: string;
+  imageAttachments?: Array<{ relativePath: string; mediaType: string }>;
 }
+
+type ImageMediaType = 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp';
+
+interface ImageContentBlock {
+  type: 'image';
+  source: { type: 'base64'; media_type: ImageMediaType; data: string };
+}
+
+interface TextContentBlock {
+  type: 'text';
+  text: string;
+}
+
+type ContentBlock = ImageContentBlock | TextContentBlock;
 
 interface ContainerOutput {
   status: 'success' | 'error';
@@ -55,7 +70,7 @@ interface SessionsIndex {
 
 interface SDKUserMessage {
   type: 'user';
-  message: { role: 'user'; content: string };
+  message: { role: 'user'; content: string | ContentBlock[] };
   parent_tool_use_id: null;
   session_id: string;
 }
@@ -77,6 +92,16 @@ class MessageStream {
     this.queue.push({
       type: 'user',
       message: { role: 'user', content: text },
+      parent_tool_use_id: null,
+      session_id: '',
+    });
+    this.waiting?.();
+  }
+
+  pushMultimodal(content: ContentBlock[]): void {
+    this.queue.push({
+      type: 'user',
+      message: { role: 'user', content },
       parent_tool_use_id: null,
       session_id: '',
     });
@@ -385,6 +410,43 @@ async function runQuery(
 }> {
   const stream = new MessageStream();
   stream.push(prompt);
+
+  // If the prompt referenced any images via [Image: attachments/...] markers,
+  // load the bytes from /workspace/group/<relativePath>, base64-encode, and
+  // push as a multimodal user message so Claude sees them as actual image
+  // content blocks (not just OCR'd text or file paths).
+  if (containerInput.imageAttachments?.length) {
+    const validMediaTypes: ImageMediaType[] = [
+      'image/jpeg',
+      'image/png',
+      'image/gif',
+      'image/webp',
+    ];
+    const blocks: ContentBlock[] = [];
+    for (const img of containerInput.imageAttachments) {
+      const imgPath = path.join('/workspace/group', img.relativePath);
+      const mediaType = validMediaTypes.includes(
+        img.mediaType as ImageMediaType,
+      )
+        ? (img.mediaType as ImageMediaType)
+        : 'image/jpeg';
+      try {
+        const data = fs.readFileSync(imgPath).toString('base64');
+        blocks.push({
+          type: 'image',
+          source: { type: 'base64', media_type: mediaType, data },
+        });
+      } catch (err) {
+        log(
+          `Failed to load image ${imgPath}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    if (blocks.length > 0) {
+      log(`Pushing ${blocks.length} image(s) as multimodal content blocks`);
+      stream.pushMultimodal(blocks);
+    }
+  }
 
   // Poll IPC for follow-up messages and _close sentinel during the query
   let ipcPolling = true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@onecli-sh/sdk": "^0.2.0",
         "better-sqlite3": "11.10.0",
         "cron-parser": "5.5.0",
-        "grammy": "^1.39.3"
+        "grammy": "^1.39.3",
+        "sharp": "^0.34.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.35.0",
@@ -29,6 +30,16 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -683,6 +694,471 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -2912,6 +3388,50 @@
         "node": ">=10"
       }
     },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -3120,6 +3640,13 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "@onecli-sh/sdk": "^0.2.0",
     "better-sqlite3": "11.10.0",
     "cron-parser": "5.5.0",
-    "grammy": "^1.39.3"
+    "grammy": "^1.39.3",
+    "sharp": "^0.34.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",

--- a/src/channels/telegram.test.ts
+++ b/src/channels/telegram.test.ts
@@ -29,6 +29,17 @@ vi.mock('../group-folder.js', () => ({
   resolveGroupFolderPath: vi.fn((folder: string) => `/tmp/test-groups/${folder}`),
 }));
 
+// Mock image processing — sharp can't run on dummy buffers in unit tests.
+// processImageFile returns a deterministic stub so the photo handler's
+// success path can be asserted without invoking real image processing.
+vi.mock('../image.js', () => ({
+  processImageFile: vi.fn(async () => ({
+    marker: '[Image: attachments/img-test.jpg]',
+    relativePath: 'attachments/img-test.jpg',
+  })),
+  parseImageReferences: vi.fn(() => []),
+}));
+
 
 // --- Grammy mock ---
 
@@ -684,10 +695,13 @@ describe('TelegramChannel', () => {
       await flushPromises();
 
       expect(currentBot().api.getFile).toHaveBeenCalledWith('large_id');
+      // The photo handler now resizes via processImageFile (mocked) and
+      // emits a [Image: ...] marker that the agent-runner translates into
+      // a multimodal content block rather than the old file path marker.
       expect(opts.onMessage).toHaveBeenCalledWith(
         'tg:100200300',
         expect.objectContaining({
-          content: '[Photo] (/workspace/group/attachments/photo_1.jpg)',
+          content: '[Image: attachments/img-test.jpg]',
         }),
       );
     });
@@ -706,8 +720,11 @@ describe('TelegramChannel', () => {
 
       expect(opts.onMessage).toHaveBeenCalledWith(
         'tg:100200300',
+        // Mocked processImageFile returns a fixed marker; the real
+        // implementation builds caption into the marker internally, so
+        // the channel layer never re-appends the caption.
         expect.objectContaining({
-          content: '[Photo] (/workspace/group/attachments/photo_1.jpg) Look at this',
+          content: '[Image: attachments/img-test.jpg]',
         }),
       );
     });

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -7,6 +7,7 @@ import { Api, Bot } from 'grammy';
 import { ASSISTANT_NAME, TRIGGER_PATTERN } from '../config.js';
 import { readEnvFile } from '../env.js';
 import { resolveGroupFolderPath } from '../group-folder.js';
+import { processImageFile } from '../image.js';
 import { logger } from '../logger.js';
 import { registerChannel, ChannelOpts } from './registry.js';
 import {
@@ -293,14 +294,91 @@ export class TelegramChannel implements Channel {
       deliver(`${placeholder}${caption}`);
     };
 
-    this.bot.on('message:photo', (ctx) => {
-      // Telegram sends multiple sizes; last is largest
+    this.bot.on('message:photo', async (ctx) => {
+      // Telegram sends multiple sizes; last is largest. Download → resize
+      // via sharp → emit `[Image: attachments/img-X.jpg]` marker so the
+      // agent-runner translates the marker into a multimodal content
+      // block (not just a file path). Falls back to `[Photo]` if any
+      // step fails.
+      const chatJid = `tg:${ctx.chat.id}`;
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) return;
+
       const photos = ctx.message.photo;
       const largest = photos?.[photos.length - 1];
-      storeMedia(ctx, '[Photo]', {
-        fileId: largest?.file_id,
-        filename: `photo_${ctx.message.message_id}`,
-      });
+      const fileId = largest?.file_id;
+      const timestamp = new Date(ctx.message.date * 1000).toISOString();
+      const senderName =
+        ctx.from?.first_name ||
+        ctx.from?.username ||
+        ctx.from?.id?.toString() ||
+        'Unknown';
+      const caption = ctx.message.caption || '';
+
+      const isGroup =
+        ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+      this.opts.onChatMetadata(
+        chatJid,
+        timestamp,
+        undefined,
+        'telegram',
+        isGroup,
+      );
+
+      const deliver = (content: string) => {
+        this.opts.onMessage(chatJid, {
+          id: ctx.message.message_id.toString(),
+          chat_jid: chatJid,
+          sender: ctx.from?.id?.toString() || '',
+          sender_name: senderName,
+          content,
+          timestamp,
+          is_from_me: false,
+        });
+      };
+
+      if (!fileId) {
+        deliver(`[Photo]${caption ? ' ' + caption : ''}`);
+        return;
+      }
+
+      const containerPath = await this.downloadFile(
+        fileId,
+        group.folder,
+        `photo_${ctx.message.message_id}`,
+      );
+      if (!containerPath) {
+        deliver(`[Photo]${caption ? ' ' + caption : ''}`);
+        return;
+      }
+
+      const groupDir = resolveGroupFolderPath(group.folder);
+      const hostPath = path.join(
+        groupDir,
+        containerPath.replace('/workspace/group/', ''),
+      );
+
+      try {
+        const processed = await processImageFile(hostPath, groupDir, {
+          caption,
+          deleteSource: true,
+        });
+        if (processed) {
+          logger.info(
+            { fileId, relativePath: processed.relativePath },
+            'Telegram image processed for vision',
+          );
+          deliver(processed.marker);
+        } else {
+          deliver(`[Photo]${caption ? ' ' + caption : ''}`);
+        }
+      } catch (err) {
+        logger.warn(
+          { err, hostPath },
+          'Image processing failed; falling back to plain photo marker',
+        );
+        deliver(`[Photo] (${containerPath})${caption ? ' ' + caption : ''}`);
+      }
     });
     this.bot.on('message:video', (ctx) => {
       storeMedia(ctx, '[Video]', {

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -43,6 +43,7 @@ export interface ContainerInput {
   isScheduledTask?: boolean;
   assistantName?: string;
   script?: string;
+  imageAttachments?: Array<{ relativePath: string; mediaType: string }>;
 }
 
 export interface ContainerOutput {

--- a/src/image.ts
+++ b/src/image.ts
@@ -1,0 +1,100 @@
+/**
+ * Image processing for multimodal vision.
+ *
+ * Channels download images to a group's `attachments/` directory and call
+ * `processImageFile()` to resize+normalize them. The resulting marker
+ * `[Image: attachments/img-...jpg]` is then embedded in the message content,
+ * which `parseImageReferences()` later extracts so the agent-runner can
+ * load and base64-encode the bytes for the Claude SDK as a multimodal block.
+ */
+import fs from 'fs';
+import path from 'path';
+import sharp from 'sharp';
+
+const MAX_DIMENSION = 1024;
+const IMAGE_REF_PATTERN = /\[Image: (attachments\/[^\]]+)\]/g;
+
+export interface ProcessedImage {
+  /** The marker to embed in the message content (e.g. "[Image: attachments/img-X.jpg]"). */
+  marker: string;
+  /** Group-relative path of the resized JPEG (e.g. "attachments/img-X.jpg"). */
+  relativePath: string;
+}
+
+export interface ImageAttachment {
+  relativePath: string;
+  mediaType: string;
+}
+
+/**
+ * Process an image that's already been downloaded to disk.
+ * Resizes (max 1024px on the longest edge), re-encodes as JPEG quality 85,
+ * writes to `attachments/img-<ts>-<rnd>.jpg`, deletes the original if requested,
+ * and returns the marker + relative path.
+ */
+export async function processImageFile(
+  sourcePath: string,
+  groupDir: string,
+  options: { caption?: string; deleteSource?: boolean } = {},
+): Promise<ProcessedImage | null> {
+  if (!fs.existsSync(sourcePath)) return null;
+
+  const buffer = fs.readFileSync(sourcePath);
+  if (buffer.length === 0) return null;
+
+  const resized = await sharp(buffer)
+    .rotate() // honor EXIF orientation, then strip it
+    .resize(MAX_DIMENSION, MAX_DIMENSION, {
+      fit: 'inside',
+      withoutEnlargement: true,
+    })
+    .jpeg({ quality: 85 })
+    .toBuffer();
+
+  const attachDir = path.join(groupDir, 'attachments');
+  fs.mkdirSync(attachDir, { recursive: true });
+
+  const filename = `img-${Date.now()}-${Math.random().toString(36).slice(2, 6)}.jpg`;
+  const filePath = path.join(attachDir, filename);
+  fs.writeFileSync(filePath, resized);
+
+  if (options.deleteSource && sourcePath !== filePath) {
+    try {
+      fs.unlinkSync(sourcePath);
+    } catch {
+      // best-effort cleanup
+    }
+  }
+
+  const relativePath = `attachments/${filename}`;
+  const caption = options.caption?.trim();
+  const marker = caption
+    ? `[Image: ${relativePath}] ${caption}`
+    : `[Image: ${relativePath}]`;
+
+  return { marker, relativePath };
+}
+
+/**
+ * Scan message content for `[Image: attachments/...]` markers and return
+ * the referenced images so the agent-runner can load + base64 + push as
+ * multimodal content blocks.
+ */
+export function parseImageReferences(
+  messages: Array<{ content: string }>,
+): ImageAttachment[] {
+  const refs: ImageAttachment[] = [];
+  const seen = new Set<string>();
+  for (const msg of messages) {
+    let match: RegExpExecArray | null;
+    IMAGE_REF_PATTERN.lastIndex = 0;
+    while ((match = IMAGE_REF_PATTERN.exec(msg.content)) !== null) {
+      const rel = match[1];
+      if (seen.has(rel)) continue;
+      seen.add(rel);
+      // processImageFile() always emits .jpg, so media_type is fixed.
+      refs.push({ relativePath: rel, mediaType: 'image/jpeg' });
+    }
+  }
+  return refs;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import {
   cleanupOrphans,
   ensureContainerRuntimeRunning,
 } from './container-runtime.js';
+import { parseImageReferences } from './image.js';
 import {
   getAllChats,
   getAllRegisteredGroups,
@@ -381,6 +382,11 @@ async function runAgent(
       }
     : undefined;
 
+  // Extract any image references (markers like [Image: attachments/...])
+  // from the formatted prompt so the agent-runner can load the bytes and
+  // push them as multimodal content blocks alongside the text prompt.
+  const imageAttachments = parseImageReferences([{ content: prompt }]);
+
   try {
     const output = await runContainerAgent(
       group,
@@ -391,6 +397,8 @@ async function runAgent(
         chatJid,
         isMain,
         assistantName: ASSISTANT_NAME,
+        imageAttachments:
+          imageAttachments.length > 0 ? imageAttachments : undefined,
       },
       (proc, containerName) =>
         queue.registerProcess(chatJid, proc, containerName, group.folder),


### PR DESCRIPTION
## Summary

Ports the existing `whatsapp/skill/image-vision` pattern to Telegram so users can send a photo in a registered chat and have the agent **see** the image directly as a native Claude multimodal content block — not OCR'd text, not a file path, the actual image bytes base64-encoded and pushed to the SDK.

Suggested branch name for upstream: `skill/image-vision` (mirroring `nanoclaw-whatsapp/skill/image-vision`).

## Architecture

The image processing pipeline is **channel-agnostic**, factored into a new `src/image.ts` module. The Telegram photo handler calls it; a future Slack/Discord/Signal handler would call the same module. Adding vision to a new channel is ~30 lines in that channel's photo handler, not a duplicate of the whole pipeline.

## Flow

1. User sends a photo in a Telegram chat
2. `message:photo` handler picks the largest size, calls `downloadFile()` (existing helper) to grab it into `groups/<folder>/attachments/`
3. New code: `processImageFile()` from `src/image.ts`
   - Reads the downloaded file
   - Rotates per EXIF orientation
   - Resizes to <=1024px on the longest edge via `sharp`
   - Re-encodes as JPEG quality 85
   - Writes as `attachments/img-<ts>-<rnd>.jpg`
   - Deletes the original raw photo
4. The channel emits a `[Image: attachments/img-X.jpg]` marker as the message content
5. `src/index.ts` — `runAgent()` calls `parseImageReferences()` on the formatted prompt and extracts the markers into a `imageAttachments` array on `ContainerInput`
6. `container/agent-runner/src/index.ts` — after `stream.push(prompt)`, each attachment is loaded from `/workspace/group/<relativePath>`, base64-encoded, wrapped in an `image` content block, and `stream.pushMultimodal()` sends it as a second user message
7. Claude receives the text prompt + the image block together, and can describe, analyze, read text from, or identify contents of the image directly

## Files changed (9)

| File | Change |
|---|---|
| `src/image.ts` | **NEW** — 100 lines, channel-agnostic `processImageFile()` + `parseImageReferences()` |
| `src/channels/telegram.ts` | Photo handler rewritten — calls `processImageFile` after download, emits new marker, falls back to `[Photo]` on error |
| `src/channels/telegram.test.ts` | Mock `../image.js`, update two photo assertions to expect the new marker |
| `src/container-runner.ts` | `ContainerInput` gains optional `imageAttachments?: Array<{relativePath, mediaType}>` |
| `src/index.ts` | `runAgent()` calls `parseImageReferences()`, passes to `runContainerAgent()` |
| `container/agent-runner/src/index.ts` | New `ContentBlock` types, `MessageStream.pushMultimodal()`, image loading block in `runQuery()`, `media_type` narrowed to the Anthropic SDK's accepted literal union |
| `package.json` / `package-lock.json` | `+sharp@^0.34.5` |
| `.claude/skills/add-image-vision/SKILL.md` | Updated to document both WhatsApp and Telegram install paths |

## Test plan

- [x] `npm run build` — clean, no TypeScript errors
- [x] `npm test` — 301/301 tests pass on the `main` baseline (2 photo handler assertions updated; no tests removed)
- [x] Live verification on macOS 26.3.1 + Apple Container 0.11.0: real photos sent in a registered Telegram chat result in the agent correctly describing image contents, reading text in screenshots (including handwritten), and identifying objects/diagrams — all via the multimodal SDK path
- [x] Fallback verified: if `processImageFile()` throws, the channel emits the legacy `[Photo] (...)` marker so the message is still delivered

## Notes for reviewers

- The `src/image.ts` module is **intentionally generic** so whatsapp's existing handler can import it too after a future cleanup. The `parseImageReferences()` function and the `ContentBlock` handling in the agent-runner are direct ports from `nanoclaw-whatsapp/skill/image-vision` and should be behaviorally identical.
- `sharp` is added as a host-side dependency only (runs in the nanoclaw process, not inside the container). The container doesn't need sharp — it just reads already-resized files via `fs.readFileSync`.
- The WhatsApp skill branch in `nanoclaw-whatsapp` predates major `telegram/main` features and can't be cleanly merged here directly. This PR takes the _pattern_ and re-implements it on top of current `telegram/main`.

## Why submit this to `nanoclaw-telegram`

Following the existing pattern: `nanoclaw-whatsapp` has a `skill/image-vision` branch in its own repo. Telegram's equivalent should live in `nanoclaw-telegram`. If maintainers prefer a different structure (e.g. shared core module in main `nanoclaw` + thin per-channel skill branches), happy to restructure.

## Relationship to other PRs

This is my second contribution to this project. Related work:

- #1735 (apple-container fixes in main nanoclaw) — still open for review
- (A parallel PR to main nanoclaw adds Google Calendar MCP integration, separate scope)

Happy to adjust scope, commit structure, or patterns if anything is off. Tested end-to-end and already in daily use on my fork.