### PR TITLE
fix(telegram): route replies into the thread of the latest inbound message

### DIFF
--- a/src/channels/telegram.test.ts
+++ b/src/channels/telegram.test.ts
@@ -986,6 +986,57 @@ describe('TelegramChannel', () => {
 
       // No error, no API call
     });
+
+    it('passes thread_id to Telegram API when provided', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await channel.sendMessage('tg:100200300', 'Threaded reply', '42');
+
+      expect(currentBot().api.sendMessage).toHaveBeenCalledWith(
+        '100200300',
+        'Threaded reply',
+        { message_thread_id: 42, parse_mode: 'Markdown' },
+      );
+    });
+
+    it('omits thread_id when not provided', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      await channel.sendMessage('tg:100200300', 'Untethered reply');
+
+      expect(currentBot().api.sendMessage).toHaveBeenCalledWith(
+        '100200300',
+        'Untethered reply',
+        { parse_mode: 'Markdown' },
+      );
+    });
+
+    it('propagates thread_id across split messages exceeding 4096 chars', async () => {
+      const opts = createTestOpts();
+      const channel = new TelegramChannel('test-token', opts);
+      await channel.connect();
+
+      const longText = 'x'.repeat(5000);
+      await channel.sendMessage('tg:100200300', longText, '7');
+
+      expect(currentBot().api.sendMessage).toHaveBeenCalledTimes(2);
+      expect(currentBot().api.sendMessage).toHaveBeenNthCalledWith(
+        1,
+        '100200300',
+        'x'.repeat(4096),
+        { message_thread_id: 7, parse_mode: 'Markdown' },
+      );
+      expect(currentBot().api.sendMessage).toHaveBeenNthCalledWith(
+        2,
+        '100200300',
+        'x'.repeat(904),
+        { message_thread_id: 7, parse_mode: 'Markdown' },
+      );
+    });
   });
 
   // --- ownsJid ---

--- a/src/db.ts
+++ b/src/db.ts
@@ -32,6 +32,7 @@ function createSchema(database: Database.Database): void {
       timestamp TEXT,
       is_from_me INTEGER,
       is_bot_message INTEGER DEFAULT 0,
+      thread_id TEXT,
       PRIMARY KEY (id, chat_jid),
       FOREIGN KEY (chat_jid) REFERENCES chats(jid)
     );
@@ -161,6 +162,13 @@ function createSchema(database: Database.Database): void {
   } catch {
     /* columns already exist */
   }
+
+  // Add thread_id column if it doesn't exist (migration for existing DBs)
+  try {
+    database.exec(`ALTER TABLE messages ADD COLUMN thread_id TEXT`);
+  } catch {
+    /* column already exists */
+  }
 }
 
 export function initDatabase(): void {
@@ -289,7 +297,7 @@ export function setLastGroupSync(): void {
  */
 export function storeMessage(msg: NewMessage): void {
   db.prepare(
-    `INSERT OR REPLACE INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me, is_bot_message, reply_to_message_id, reply_to_message_content, reply_to_sender_name) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT OR REPLACE INTO messages (id, chat_jid, sender, sender_name, content, timestamp, is_from_me, is_bot_message, reply_to_message_id, reply_to_message_content, reply_to_sender_name, thread_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     msg.id,
     msg.chat_jid,
@@ -302,6 +310,7 @@ export function storeMessage(msg: NewMessage): void {
     msg.reply_to_message_id ?? null,
     msg.reply_to_message_content ?? null,
     msg.reply_to_sender_name ?? null,
+    msg.thread_id ?? null,
   );
 }
 
@@ -347,7 +356,7 @@ export function getNewMessages(
   const sql = `
     SELECT * FROM (
       SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me,
-             reply_to_message_id, reply_to_message_content, reply_to_sender_name
+             reply_to_message_id, reply_to_message_content, reply_to_sender_name, thread_id
       FROM messages
       WHERE timestamp > ? AND chat_jid IN (${placeholders})
         AND is_bot_message = 0 AND content NOT LIKE ?
@@ -381,7 +390,7 @@ export function getMessagesSince(
   const sql = `
     SELECT * FROM (
       SELECT id, chat_jid, sender, sender_name, content, timestamp, is_from_me,
-             reply_to_message_id, reply_to_message_content, reply_to_sender_name
+             reply_to_message_id, reply_to_message_content, reply_to_sender_name, thread_id
       FROM messages
       WHERE chat_jid = ? AND timestamp > ?
         AND is_bot_message = 0 AND content NOT LIKE ?

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,11 @@ let lastTimestamp = '';
 let sessions: Record<string, string> = {};
 let registeredGroups: Record<string, RegisteredGroup> = {};
 let lastAgentTimestamp: Record<string, string> = {};
+// Tracks the thread_id of the most recent inbound message per chat.
+// Used to route the agent's reply into the thread the user most recently wrote in.
+// Updated in processGroupMessages (initial batch) and startMessageLoop (piped messages),
+// read from the streaming callback at send time.
+const lastInboundThreadId: Record<string, string | undefined> = {};
 let messageLoopRunning = false;
 
 const channels: Channel[] = [];
@@ -252,6 +257,13 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
 
   const prompt = formatMessages(missedMessages, TIMEZONE);
 
+  // Track the thread_id of the most recent inbound message so the streaming
+  // callback (below) and the piping path in startMessageLoop can route the
+  // reply into the thread the user last wrote in. Channels without threads
+  // (WhatsApp) ignore this.
+  lastInboundThreadId[chatJid] =
+    missedMessages[missedMessages.length - 1].thread_id || undefined;
+
   // Advance cursor so the piping path in startMessageLoop won't re-fetch
   // these messages. Save the old cursor so we can roll back on error.
   const previousCursor = lastAgentTimestamp[chatJid] || '';
@@ -293,7 +305,9 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
       const text = raw.replace(/<internal>[\s\S]*?<\/internal>/g, '').trim();
       logger.info({ group: group.name }, `Agent output: ${raw.length} chars`);
       if (text) {
-        await channel.sendMessage(chatJid, text);
+        // Read latest inbound thread at send time so replies follow the
+        // user even when new messages are piped mid-stream.
+        await channel.sendMessage(chatJid, text, lastInboundThreadId[chatJid]);
         outputSentToUser = true;
       }
       // Only reset idle timer on actual results, not session-update markers (result: null)
@@ -520,6 +534,10 @@ async function startMessageLoop(): Promise<void> {
             );
             lastAgentTimestamp[chatJid] =
               messagesToSend[messagesToSend.length - 1].timestamp;
+            // Update reply-thread tracker so the running agent's next output
+            // is routed into the thread of the most recently piped message.
+            lastInboundThreadId[chatJid] =
+              messagesToSend[messagesToSend.length - 1].thread_id || undefined;
             saveState();
             // Show typing indicator while the container processes the piped message
             channel

--- a/src/router.ts
+++ b/src/router.ts
@@ -45,10 +45,11 @@ export function routeOutbound(
   channels: Channel[],
   jid: string,
   text: string,
+  threadId?: string,
 ): Promise<void> {
   const channel = channels.find((c) => c.ownsJid(jid) && c.isConnected());
   if (!channel) throw new Error(`No channel for JID: ${jid}`);
-  return channel.sendMessage(jid, text);
+  return channel.sendMessage(jid, text, threadId);
 }
 
 export function findChannel(

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,7 +87,7 @@ export interface TaskRunLog {
 export interface Channel {
   name: string;
   connect(): Promise<void>;
-  sendMessage(jid: string, text: string): Promise<void>;
+  sendMessage(jid: string, text: string, threadId?: string): Promise<void>;
   isConnected(): boolean;
   ownsJid(jid: string): boolean;
   disconnect(): Promise<void>;


### PR DESCRIPTION
Closes #144.

## Summary
- Wires `thread_id` all the way from `ctx.message.message_thread_id` → DB → agent batch → `TelegramChannel.sendMessage()` so the bot's reply lands in the same topic the user last wrote in.
- Memory stays shared across topics — single agent run per group, reply routed to the most recently written thread at send time.
- Handles mid-stream topic switches (new messages piped to an already-active container via `queue.sendMessage`).

## What changed
6 files, `+85 / -6` (excluding the skill-scoped `whatsapp.ts` from the upstream branch).

- `src/types.ts`: `Channel.sendMessage` gains optional `threadId?: string`.
- `src/router.ts`: `routeOutbound` propagates `threadId`.
- `src/db.ts`:
  - `thread_id TEXT` column added to `messages` table + idempotent ALTER TABLE migration for existing DBs.
  - `storeMessage` persists it, `getNewMessages` / `getMessagesSince` SELECT it.
- `src/index.ts`:
  - New `lastInboundThreadId: Record<string, string | undefined>` tracker.
  - Updated in `processGroupMessages` (initial batch) **and** in `startMessageLoop` right after `queue.sendMessage` succeeds.
  - Read from the `runAgent` streaming callback at **send time** (not as a captured closure) so mid-stream topic switches are respected.
- `src/channels/telegram.test.ts`: new tests for `threadId` propagation, including split-message path.

`telegram.ts` itself needs no change — its `sendMessage` signature already accepted `threadId` and forwarded `message_thread_id` to the Bot API. The plumbing between capture and send was the missing piece.

## Subtle bug found during testing

First attempt captured `replyThreadId` once at the top of `processGroupMessages` and read it from the streaming callback closure. That broke whenever the agent container was kept alive across batches and a new message was piped via `queue.sendMessage` → IPC file → container stdin: the subsequent agent output still resolved the stale closure variable, not the latest message's thread. Symptom: reply for a thread-tagged message shows `threadId: undefined` in logs.

Fix: dynamic lookup at send time (`lastInboundThreadId[chatJid]`) plus updating the tracker from the pipe path in `startMessageLoop`. Any output produced after a message is piped now routes to that message's thread.

## Tests
- Suite: **304 / 304 green**.
- New: `passes thread_id to Telegram API when provided`, `omits thread_id when not provided`, `propagates thread_id across split messages exceeding 4096 chars`.

## Known limitations

1. **Cross-thread batches in a single agent run.** If the user writes in topic A then topic B between two agent runs, both messages end up in the same prompt and the single reply goes only to the **most recent** thread (topic B). Topic A won't see a textual response, though the agent retains the context and can address it in the next exchange. Deliberate tradeoff: batching per thread would mean separate agent runs, sacrificing shared memory across topics — this is exactly what we wanted to preserve.

2. **Mid-reply topic switch.** If the agent produces a multi-part response and a new message arrives in a different thread while it's still streaming, the later parts of that response are routed to the new thread. Rare edge case.

3. **No per-message thread attribution in the prompt.** The `<message>` XML sent to the agent does not currently include a thread attribute — the agent sees a flat stream. Fine for the "shared memory" UX; could be extended later if needed.

## Migration notes
The `ALTER TABLE` migration runs automatically on next startup for existing installs. Pre-existing messages have `thread_id = NULL` (they predate the feature), so the bot continues to reply in General until a new thread-tagged message is received — correct behavior.

## Test plan
- [ ] Apply skill branch, start service.
- [ ] Send a message in a Telegram topic → bot replies in that topic.
- [ ] Send a message in General → bot replies in General.
- [ ] Send messages in two different topics back-to-back → bot replies in the thread of the most recent message (known limitation, documented above).
- [ ] Verify `thread_id` column exists in `store/messages.db` after first startup.
- [ ] Verify logs show `threadId: "<id>"` on `Telegram message sent` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)