### PR TITLE
feat(telegram): two-way emoji reactions channel

### DIFF
--- a/.claude/skills/add-telegram-reactions/SKILL.md
+++ b/.claude/skills/add-telegram-reactions/SKILL.md
@@ -1,0 +1,410 @@
+---
+name: add-telegram-reactions
+description: Add two-way emoji reactions between the user and the NanoClaw agent in Telegram. The agent can react to incoming messages as a lightweight status signal (👀 → 👏) via the new `react_to_message` MCP tool; user reactions on the agent's messages arrive as synthetic `[Reaction: X] on message Y` events that the agent interprets as shortcut commands.
+---
+
+# Add Telegram Emoji Reactions
+
+This skill adds a bidirectional emoji-reaction channel to the NanoClaw Telegram integration. It delivers two things:
+
+1. **Agent → user status signals.** The agent can call the new `react_to_message(message_id, emoji)` MCP tool to react to the user's incoming message as a quick acknowledgment — 👀 when it starts, 👏 when it finishes, 💔 on failure, ✍ after a wiki ingest, etc. The user sees an instant reaction on their own message rather than waiting for a text reply, which is especially useful for long-running tasks (web research, document ingest, scheduled reports).
+
+2. **User → agent shortcut commands.** When the user adds an emoji reaction to one of the agent's messages, the Telegram channel's new `message_reaction` handler delivers it back as a synthetic user message in the form `[Reaction: X] on message Y`. The agent interprets this as a shortcut command (👍 confirm, ❤ ingest to wiki, 🤩 repeat, 🔥 pin, 👌 close Todoist task, etc.) per the user-specific skill doc in the group.
+
+The actual semantics of each emoji are **user-specific** and live in the group's skill docs / `CLAUDE.md`. This skill ships the transport layer — not the command vocabulary.
+
+## What this adds
+
+- `mcp__nanoclaw__react_to_message` MCP tool in the agent-runner
+- `reactToMessage?(jid, messageId, emoji)` optional method on the `Channel` interface (`src/types.ts`)
+- `bot.on('message_reaction')` handler + `reactToMessage()` method in `src/channels/telegram.ts`
+- `allowed_updates: ['message', 'edited_message', 'callback_query', 'message_reaction']` in `bot.start()` (grammy's default polling set does NOT subscribe to reaction updates — this is required)
+- `type: 'react'` IPC handler in `src/ipc.ts` with sender-group authorization (only the owning group or main group can emit reactions into a chat)
+- `reactToMessage` wire-through from `startIpcWatcher` in `src/index.ts` via `findChannel(jid)` → `channel.reactToMessage`
+
+If a channel does not implement `reactToMessage` (e.g. WhatsApp without the parallel reactions skill), the IPC is silently dropped with a `warn` log rather than throwing — so agents running on other channels continue to work cleanly even when they attempt to use the tool.
+
+## Prerequisites
+
+- The Telegram channel must already be installed (`/add-telegram` — the `nanoclaw-telegram` main branch merged into your NanoClaw install)
+- Node.js, container runtime running (Docker or Apple Container)
+- No new npm dependencies — uses grammy's existing `Bot.api.setMessageReaction`
+
+## ⚠️ Telegram Bot API whitelist
+
+Telegram restricts bot reactions to a fixed whitelist of ~74 emoji. As of Bot API 7.0 it includes:
+
+```
+👍 👎 ❤ 🔥 🥰 👏 😁 🤔 🤯 😱 🤬 😢 🎉 🤩 🤮 💩 🙏 👌 🕊 🤡
+🥱 🥴 😍 🐳 ❤‍🔥 🌚 🌭 💯 🤣 ⚡ 🍌 🏆 💔 🤨 😐 🍓 🍾 💋 🖕 😈
+😴 😭 🤓 👻 👨‍💻 👀 🎃 🙈 😇 😨 🤝 ✍ 🤗 🫡 🎅 🎄 ☃ 💅 🤪 🗿
+🆒 💘 🙉 🦄 😘 💊 🙊 😎 👾 🤷‍♂ 🤷 🤷‍♀ 😡
+```
+
+Emoji outside this list fail the API call with `Bad Request: REACTION_INVALID`. The `reactToMessage` wrapper logs at `warn` level on failure so these can be noticed and replaced over time. When designing a command vocabulary in your group's skill doc, pick exclusively from the whitelist — grammy's own types enforce it at compile time in the channel code.
+
+Custom emoji reactions are premium-only and are not supported by this skill.
+
+## Phase 1: Pre-flight
+
+### Check if already applied
+
+```bash
+grep -q "reactToMessage" src/types.ts && echo "Already applied" || echo "Not applied"
+```
+
+If already applied, skip to **Phase 3: Verify**.
+
+## Phase 2: Apply code changes
+
+Five files change. All edits are additive — no behaviour changes for existing callers, and the conditional `reactToMessage?` on the `Channel` interface means channels that don't implement reactions keep working.
+
+### `src/types.ts`
+
+Add to the `Channel` interface:
+
+```ts
+// Optional: send an emoji reaction to a specific message. Channels that
+// have a reactions API (Telegram) implement this; others leave it
+// undefined and the host layer drops react_to_message IPCs with a warn.
+reactToMessage?(jid: string, messageId: string, emoji: string): Promise<void>;
+```
+
+### `src/ipc.ts`
+
+Add to `IpcDeps`:
+
+```ts
+reactToMessage?: (
+  jid: string,
+  messageId: string,
+  emoji: string,
+) => Promise<void>;
+```
+
+Inside the `messageFiles` processing loop, add a new branch after the existing `data.type === 'message'` block:
+
+```ts
+} else if (
+  data.type === 'react' &&
+  data.chatJid &&
+  data.messageId &&
+  data.emoji
+) {
+  const targetGroup = registeredGroups[data.chatJid];
+  const authorized =
+    isMain || (targetGroup && targetGroup.folder === sourceGroup);
+  if (!authorized) {
+    logger.warn(
+      { chatJid: data.chatJid, sourceGroup },
+      'Unauthorized IPC reaction attempt blocked',
+    );
+  } else if (!deps.reactToMessage) {
+    logger.warn(
+      { chatJid: data.chatJid, sourceGroup, emoji: data.emoji },
+      'IPC reaction dropped — no channel supports reactToMessage',
+    );
+  } else {
+    await deps.reactToMessage(data.chatJid, data.messageId, data.emoji);
+    logger.info(
+      {
+        chatJid: data.chatJid,
+        sourceGroup,
+        messageId: data.messageId,
+        emoji: data.emoji,
+      },
+      'IPC reaction sent',
+    );
+  }
+}
+```
+
+### `src/channels/telegram.ts`
+
+Add a private field `botId: number | null = null` to the `TelegramChannel` class.
+
+Inside `connect()`, after the existing media handlers and before `this.bot.catch(...)`, add the incoming-reactions handler:
+
+```ts
+this.bot.on('message_reaction', async (ctx) => {
+  const chatJid = `tg:${ctx.chat.id}`;
+  const group = this.opts.registeredGroups()[chatJid];
+  if (!group) return;
+
+  const reaction = ctx.messageReaction;
+  if (!reaction) return;
+
+  // Filter the bot's own reactions out of the inbound stream
+  const user = reaction.user;
+  const reactorId = user?.id;
+  if (this.botId != null && reactorId === this.botId) return;
+
+  const timestamp = new Date(reaction.date * 1000).toISOString();
+  const senderName = user
+    ? user.first_name || user.username || user.id.toString()
+    : 'Unknown';
+  const sender = reactorId != null ? reactorId.toString() : '';
+
+  // Deliver NEWLY added emoji only (set difference new - old)
+  const oldEmojis = new Set<string>();
+  for (const r of reaction.old_reaction || []) {
+    if (r.type === 'emoji') oldEmojis.add(r.emoji);
+  }
+  const addedEmojis: string[] = [];
+  for (const r of reaction.new_reaction || []) {
+    if (r.type === 'emoji' && !oldEmojis.has(r.emoji)) {
+      addedEmojis.push(r.emoji);
+    }
+  }
+  if (addedEmojis.length === 0) return;
+
+  const isGroup =
+    ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+  this.opts.onChatMetadata(
+    chatJid,
+    timestamp,
+    undefined,
+    'telegram',
+    isGroup,
+  );
+
+  for (const emoji of addedEmojis) {
+    this.opts.onMessage(chatJid, {
+      id: `reaction-${reaction.message_id}-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2, 6)}`,
+      chat_jid: chatJid,
+      sender,
+      sender_name: senderName,
+      content: `[Reaction: ${emoji}] on message ${reaction.message_id}`,
+      timestamp,
+      is_from_me: false,
+    });
+  }
+});
+```
+
+Add the `reactToMessage` method to the class:
+
+```ts
+async reactToMessage(
+  jid: string,
+  messageId: string,
+  emoji: string,
+): Promise<void> {
+  if (!this.bot) {
+    logger.warn('Telegram bot not initialized (reactToMessage)');
+    return;
+  }
+  try {
+    const numericChatId = Number(jid.replace(/^tg:/, ''));
+    const numericMsgId = Number.parseInt(messageId, 10);
+    if (Number.isNaN(numericChatId) || Number.isNaN(numericMsgId)) {
+      logger.warn(
+        { jid, messageId },
+        'reactToMessage: invalid chat or message id',
+      );
+      return;
+    }
+    await this.bot.api.setMessageReaction(numericChatId, numericMsgId, [
+      { type: 'emoji', emoji: emoji as never },
+    ]);
+    logger.info({ jid, messageId, emoji }, 'Telegram reaction sent');
+  } catch (err) {
+    logger.warn(
+      { jid, messageId, emoji, err },
+      'Failed to send Telegram reaction (likely REACTION_INVALID — emoji not in Bot API whitelist)',
+    );
+  }
+}
+```
+
+Update the existing `this.bot.start({ onStart: ... })` call to include `allowed_updates` and capture `botId`:
+
+```ts
+this.bot!.start({
+  allowed_updates: [
+    'message',
+    'edited_message',
+    'callback_query',
+    'message_reaction',
+  ],
+  onStart: (botInfo) => {
+    this.botId = botInfo.id;
+    // ...existing logging...
+    resolve();
+  },
+});
+```
+
+### `container/agent-runner/src/ipc-mcp-stdio.ts`
+
+Register a new MCP tool after the existing `send_message` tool:
+
+```ts
+server.tool(
+  'react_to_message',
+  `Send an emoji reaction to a specific message in the chat. A lightweight
+status signal without a full text reply. Telegram only: other channels
+silently drop the IPC. Telegram Bot API only accepts emoji from a fixed
+~74 whitelist; unsupported emoji fail silently at the API layer and are
+logged at warn level on the host.`,
+  {
+    message_id: z.string().describe('The message id to react to'),
+    emoji: z.string().describe('The emoji character (must be in whitelist)'),
+  },
+  async (args) => {
+    writeIpcFile(MESSAGES_DIR, {
+      type: 'react',
+      chatJid,
+      messageId: args.message_id,
+      emoji: args.emoji,
+      groupFolder,
+      timestamp: new Date().toISOString(),
+    });
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `Reaction ${args.emoji} queued for message ${args.message_id}.`,
+        },
+      ],
+    };
+  },
+);
+```
+
+### `src/index.ts`
+
+In the `startIpcWatcher({ ... })` call, add a `reactToMessage` closure alongside the existing `sendMessage`:
+
+```ts
+reactToMessage: async (jid, messageId, emoji) => {
+  const channel = findChannel(channels, jid);
+  if (!channel) {
+    logger.warn(
+      { jid, messageId, emoji },
+      'reactToMessage: no channel owns JID',
+    );
+    return;
+  }
+  if (!channel.reactToMessage) {
+    logger.warn(
+      { jid, channel: channel.name, messageId, emoji },
+      'reactToMessage: channel does not implement reactions, dropping',
+    );
+    return;
+  }
+  await channel.reactToMessage(jid, messageId, emoji);
+},
+```
+
+### Validate
+
+```bash
+npm run build
+npm test
+```
+
+All tests must pass — the change is purely additive and no existing tests touch the new paths.
+
+## Phase 3: Verify
+
+### Rebuild + restart
+
+```bash
+npm run build
+./container/build.sh        # rebuild container to pick up the new MCP tool
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw   # macOS
+# Linux: systemctl --user restart nanoclaw
+```
+
+On Apple Container, the buildkit may need a clean prune before the container rebuild picks up the agent-runner changes:
+
+```bash
+container builder stop && container builder rm && container builder start
+./container/build.sh
+```
+
+### Sanity checks
+
+1. Start a chat with your bot. Send any message.
+2. Ask the agent to react: **"отреагируй на моё прошлое сообщение эмодзи 👀"** (or in English). It should invoke `react_to_message` and you should see a 👀 reaction appear on your message in Telegram within a second or two.
+3. You react with 👍 on any message the agent sent. Check container logs for `[Reaction: 👍] on message <id>` as a synthetic user message being delivered.
+4. `grep "Telegram reaction sent" logs/nanoclaw.log` should show successful reactions.
+5. `grep "REACTION_INVALID" logs/nanoclaw.log` should show any emoji that failed the whitelist — if so, pick replacements from the list at the top of this doc.
+
+## Phase 4: Design a command vocabulary
+
+This skill ships the **transport layer only**. To actually use the bidirectional channel, document a command vocabulary in your group's skill docs or `CLAUDE.md`. Example sections:
+
+### Agent → user status signals
+
+Pick from the whitelist. Common choices:
+
+| Emoji | Meaning |
+|---|---|
+| 👀 | Seen, starting |
+| ⚡ | Long-running task |
+| 👏 | Done |
+| 💔 | Failed |
+| 🤔 | Need info |
+| 🫡 | Queued / scheduled |
+| ✍ | Wiki ingest |
+| 🙏 | Retrying |
+| 🙊 | Acknowledged silently |
+
+### User → agent commands
+
+Also from the whitelist:
+
+| Emoji | Command |
+|---|---|
+| 👍 | Confirm / approve last pending |
+| 👎 | Reject / cancel |
+| ❤ | Remember / ingest to knowledge base |
+| 🤩 | Repeat last action |
+| 🔥 | Important / pin |
+| 👌 | Mark done |
+| 🤬 | Stop / delete |
+| 🤔 | Explain in more detail |
+| 🫡 | Follow-up reminder |
+| 😴 | Quiet, no text reply |
+
+Adapt the table to your own workflow — these are defaults.
+
+## Troubleshooting
+
+### Reactions from the user don't arrive
+
+- Check logs for `Telegram bot connected` — the connect trace should show the bot ID. If the bot started but no reaction events arrive, `allowed_updates` is probably missing `message_reaction`. Re-verify the `bot.start()` call.
+- In group chats, the bot must be an admin to receive reaction updates. In private DMs, this is not required.
+- The Bot API delivers reactions only for reactions added AFTER the bot started. Older reactions are not replayed.
+
+### Agent's reactions don't appear
+
+- `grep "REACTION_INVALID" logs/nanoclaw.log` — if present, the emoji isn't in the whitelist. Replace it.
+- `grep "Telegram bot not initialized" logs/nanoclaw.log` — channel was reloaded mid-flight. Restart the service.
+- In a group chat, bot permissions must include the ability to add reactions; default admin permissions usually grant this.
+
+### Agent sees its own reactions as commands
+
+- The `botId` filter requires that `connect()` populates `this.botId = botInfo.id` in `onStart`. Verify the code change landed.
+
+## Removal
+
+1. Revert the 5 file changes (or cherry-pick the commit with `-R`)
+2. `npm run build && ./container/build.sh && launchctl kickstart -k gui/$(id -u)/com.nanoclaw`
+3. No database cleanup is needed — reactions are ephemeral, not persisted
+
+## Relationship to the whatsapp/skill/reactions branch
+
+There is an existing `skill/reactions` branch on the `nanoclaw-whatsapp` repo that also adds reaction support. That branch takes a heavier approach: a full `src/status-tracker.ts` forward-only state machine with persistence and retry, plus a `reactions` SQLite table for history. It's WhatsApp-only because it modifies WhatsApp channel files directly.
+
+This Telegram skill is **lighter**:
+
+- No state machine — the agent's CLAUDE.md is the state model
+- No `reactions` table — reactions are ephemeral signals, not a persistent log
+- Two-way from day one (the whatsapp skill is primarily one-way status, with reactions-as-log as a side effect)
+
+If you want both channels to have reactions, both skills can coexist — they share the same `Channel.reactToMessage` interface boundary introduced here, and the host layer routes based on `findChannel(jid)`.

--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -68,6 +68,58 @@ server.tool(
 );
 
 server.tool(
+  'react_to_message',
+  `Send an emoji reaction to a specific message in the chat. A lightweight status signal or command-acknowledgment without sending a full text reply.
+
+CHANNEL SUPPORT: currently implemented for Telegram. On channels without reaction support the IPC is silently dropped at the host layer — check channel capabilities before relying on this tool for critical feedback.
+
+TELEGRAM WHITELIST: the Telegram Bot API only accepts reactions from a fixed whitelist of ~74 emoji. If the emoji is not in the whitelist, the reaction silently fails at the API layer and is logged at warn level on the host (\`REACTION_INVALID\`). Fall back to a short text reply if the reaction did not land.
+
+Suggested status signals (agent → user, reacting to an incoming user message):
+• 👀  seen, starting to process
+• ⚡  working on a long task (browser, research, ingest)
+• 👏  done successfully
+• 🤔  need clarification from the user
+• 🫡  scheduled / queued for later
+• ✍  ingested into the wiki
+• 🙏  repeating / retrying
+• 💔  failed, could not complete
+• 🙊  acknowledged silently, no text reply needed
+
+When the user reacts to one of the agent's own messages, the update is delivered back as a synthetic incoming message in the form: "[Reaction: X] on message Y". Those should be interpreted as shortcut commands — the exact meaning is user-specific and should live in the group's CLAUDE.md or an associated skill doc.`,
+  {
+    message_id: z
+      .string()
+      .describe(
+        'The message ID to react to. For incoming user messages use the id field. For your own previous messages, note the id at send time.',
+      ),
+    emoji: z
+      .string()
+      .describe(
+        'The emoji character to react with. Use one from the whitelist documented above — other emoji will silently fail on the API.',
+      ),
+  },
+  async (args) => {
+    writeIpcFile(MESSAGES_DIR, {
+      type: 'react',
+      chatJid,
+      messageId: args.message_id,
+      emoji: args.emoji,
+      groupFolder,
+      timestamp: new Date().toISOString(),
+    });
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `Reaction ${args.emoji} queued for message ${args.message_id}.`,
+        },
+      ],
+    };
+  },
+);
+
+server.tool(
   'schedule_task',
   `Schedule a recurring or one-time task. The task will run as a full agent with access to all tools. Returns the task ID for future reference. To modify an existing task, use update_task instead.
 

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -51,6 +51,7 @@ export class TelegramChannel implements Channel {
   private bot: Bot | null = null;
   private opts: TelegramChannelOpts;
   private botToken: string;
+  private botId: number | null = null;
 
   constructor(botToken: string, opts: TelegramChannelOpts) {
     this.botToken = botToken;
@@ -336,15 +337,86 @@ export class TelegramChannel implements Channel {
     this.bot.on('message:location', (ctx) => storeMedia(ctx, '[Location]'));
     this.bot.on('message:contact', (ctx) => storeMedia(ctx, '[Contact]'));
 
+    // Two-way emoji reactions channel. Incoming reactions from registered
+    // chats are delivered as synthetic `[Reaction: X] on message Y` user
+    // messages that the agent can interpret as shortcut commands per the
+    // user's skill doc. The bot's own reactions (via setMessageReaction)
+    // are filtered out so the agent doesn't echo its own status signals.
+    this.bot.on('message_reaction', async (ctx) => {
+      const chatJid = `tg:${ctx.chat.id}`;
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) return;
+
+      const reaction = ctx.messageReaction;
+      if (!reaction) return;
+
+      const user = reaction.user;
+      const reactorId = user?.id;
+      if (this.botId != null && reactorId === this.botId) return;
+
+      const timestamp = new Date(reaction.date * 1000).toISOString();
+      const senderName = user
+        ? user.first_name || user.username || user.id.toString()
+        : 'Unknown';
+      const sender = reactorId != null ? reactorId.toString() : '';
+
+      // Deliver only NEWLY added emoji reactions (set difference new - old).
+      // Removed reactions are ignored — un-reactions are not commands.
+      const oldEmojis = new Set<string>();
+      for (const r of reaction.old_reaction || []) {
+        if (r.type === 'emoji') oldEmojis.add(r.emoji);
+      }
+      const addedEmojis: string[] = [];
+      for (const r of reaction.new_reaction || []) {
+        if (r.type === 'emoji' && !oldEmojis.has(r.emoji)) {
+          addedEmojis.push(r.emoji);
+        }
+      }
+
+      if (addedEmojis.length === 0) return;
+
+      const isGroup =
+        ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+      this.opts.onChatMetadata(
+        chatJid,
+        timestamp,
+        undefined,
+        'telegram',
+        isGroup,
+      );
+
+      for (const emoji of addedEmojis) {
+        this.opts.onMessage(chatJid, {
+          id: `reaction-${reaction.message_id}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+          chat_jid: chatJid,
+          sender,
+          sender_name: senderName,
+          content: `[Reaction: ${emoji}] on message ${reaction.message_id}`,
+          timestamp,
+          is_from_me: false,
+        });
+      }
+    });
+
     // Handle errors gracefully
     this.bot.catch((err) => {
       logger.error({ err: err.message }, 'Telegram bot error');
     });
 
-    // Start polling — returns a Promise that resolves when started
+    // Start polling — returns a Promise that resolves when started.
+    // `allowed_updates` must explicitly include `message_reaction` —
+    // grammy's default polling set does NOT subscribe to reaction updates,
+    // so they would never be delivered without this.
     return new Promise<void>((resolve) => {
       this.bot!.start({
+        allowed_updates: [
+          'message',
+          'edited_message',
+          'callback_query',
+          'message_reaction',
+        ],
         onStart: (botInfo) => {
+          this.botId = botInfo.id;
           logger.info(
             { username: botInfo.username, id: botInfo.id },
             'Telegram bot connected',
@@ -357,6 +429,48 @@ export class TelegramChannel implements Channel {
         },
       });
     });
+  }
+
+  /**
+   * Send an emoji reaction to a specific message. Used by the
+   * `react_to_message` MCP tool so the agent can signal status or
+   * command-acknowledgments without a full text reply. Telegram only
+   * allows a fixed whitelist of ~74 emoji for reactions; unsupported
+   * emoji yield a `REACTION_INVALID` error which is logged at warn level
+   * so the set can be tuned over time.
+   */
+  async reactToMessage(
+    jid: string,
+    messageId: string,
+    emoji: string,
+  ): Promise<void> {
+    if (!this.bot) {
+      logger.warn('Telegram bot not initialized (reactToMessage)');
+      return;
+    }
+    try {
+      const numericChatId = Number(jid.replace(/^tg:/, ''));
+      const numericMsgId = Number.parseInt(messageId, 10);
+      if (Number.isNaN(numericChatId) || Number.isNaN(numericMsgId)) {
+        logger.warn(
+          { jid, messageId },
+          'reactToMessage: invalid chat or message id',
+        );
+        return;
+      }
+      await this.bot.api.setMessageReaction(numericChatId, numericMsgId, [
+        { type: 'emoji', emoji: emoji as never },
+      ]);
+      logger.info(
+        { jid, messageId, emoji },
+        'Telegram reaction sent',
+      );
+    } catch (err) {
+      logger.warn(
+        { jid, messageId, emoji, err },
+        'Failed to send Telegram reaction (likely REACTION_INVALID — emoji not in Bot API whitelist)',
+      );
+    }
   }
 
   async sendMessage(

--- a/src/index.ts
+++ b/src/index.ts
@@ -717,6 +717,24 @@ async function main(): Promise<void> {
       if (!channel) throw new Error(`No channel for JID: ${jid}`);
       return channel.sendMessage(jid, text);
     },
+    reactToMessage: async (jid, messageId, emoji) => {
+      const channel = findChannel(channels, jid);
+      if (!channel) {
+        logger.warn(
+          { jid, messageId, emoji },
+          'reactToMessage: no channel owns JID',
+        );
+        return;
+      }
+      if (!channel.reactToMessage) {
+        logger.warn(
+          { jid, channel: channel.name, messageId, emoji },
+          'reactToMessage: channel does not implement reactions, dropping',
+        );
+        return;
+      }
+      await channel.reactToMessage(jid, messageId, emoji);
+    },
     registeredGroups: () => registeredGroups,
     registerGroup,
     syncGroups: async (force: boolean) => {

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -23,6 +23,15 @@ export interface IpcDeps {
     registeredJids: Set<string>,
   ) => void;
   onTasksChanged: () => void;
+  // Optional: send an emoji reaction to a message. Populated by the host
+  // only if at least one connected channel implements the
+  // `Channel.reactToMessage` hook. If undefined, IPC files with
+  // `type: 'react'` are silently dropped with a warn log.
+  reactToMessage?: (
+    jid: string,
+    messageId: string,
+    emoji: string,
+  ) => Promise<void>;
 }
 
 let ipcWatcherRunning = false;
@@ -90,6 +99,48 @@ export function startIpcWatcher(deps: IpcDeps): void {
                   logger.warn(
                     { chatJid: data.chatJid, sourceGroup },
                     'Unauthorized IPC message attempt blocked',
+                  );
+                }
+              } else if (
+                data.type === 'react' &&
+                data.chatJid &&
+                data.messageId &&
+                data.emoji
+              ) {
+                // Same authorization as IPC messages — only the owning
+                // group (or main group) can push reactions into this chat.
+                const targetGroup = registeredGroups[data.chatJid];
+                const authorized =
+                  isMain ||
+                  (targetGroup && targetGroup.folder === sourceGroup);
+                if (!authorized) {
+                  logger.warn(
+                    { chatJid: data.chatJid, sourceGroup },
+                    'Unauthorized IPC reaction attempt blocked',
+                  );
+                } else if (!deps.reactToMessage) {
+                  logger.warn(
+                    {
+                      chatJid: data.chatJid,
+                      sourceGroup,
+                      emoji: data.emoji,
+                    },
+                    'IPC reaction dropped — no channel supports reactToMessage',
+                  );
+                } else {
+                  await deps.reactToMessage(
+                    data.chatJid,
+                    data.messageId,
+                    data.emoji,
+                  );
+                  logger.info(
+                    {
+                      chatJid: data.chatJid,
+                      sourceGroup,
+                      messageId: data.messageId,
+                      emoji: data.emoji,
+                    },
+                    'IPC reaction sent',
                   );
                 }
               }

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,10 @@ export interface Channel {
   setTyping?(jid: string, isTyping: boolean): Promise<void>;
   // Optional: sync group/chat names from the platform.
   syncGroups?(force: boolean): Promise<void>;
+  // Optional: send an emoji reaction to a specific message. Channels that
+  // have a reactions API (Telegram) implement this; others leave it
+  // undefined and the host layer drops react_to_message IPCs with a warn.
+  reactToMessage?(jid: string, messageId: string, emoji: string): Promise<void>;
 }
 
 // Callback type that channels use to deliver inbound messages


### PR DESCRIPTION
## Summary

Adds a bidirectional emoji-reactions channel to the Telegram integration:

- **Agent → user status signals**: the agent can call a new `react_to_message(message_id, emoji)` MCP tool to react to the user's incoming message as an instant acknowledgment (👀 on start, 👏 on completion, 💔 on failure, ✍ after wiki ingest, etc.). Especially valuable for long-running tasks (web research, ingest pipelines, morning briefs) where the user would otherwise wait in uncertainty.
- **User → agent shortcut commands**: user reactions on the agent's messages arrive back through a new `bot.on('message_reaction')` handler as synthetic `[Reaction: X] on message Y` user messages. The agent interprets them as shortcut commands per the group's own skill / CLAUDE.md vocabulary (👍 confirm, ❤ ingest, 🤩 repeat, 🔥 pin, 👌 mark done, 🤬 stop, 🫡 follow-up, 😴 quiet, etc.).

Suggested upstream branch name: `skill/telegram-reactions` (mirroring `nanoclaw-whatsapp/skill/reactions`).

## Design

**Transport layer only.** The exact meaning of each emoji is user-specific and lives in the group's skill doc / `CLAUDE.md`. This PR ships only the plumbing — agents pick emoji from the Telegram whitelist and users map semantics however they want.

**Two-way from day one.** Unlike the existing whatsapp reactions skill which was designed primarily around one-way status signalling (with a persistent reactions table as a side effect), this one is explicitly two-way: user reactions come back as commands. No `reactions` database table — reactions are treated as ephemeral signals, not a persistent log.

**Lighter than the whatsapp approach.** No `src/status-tracker.ts` state machine, no persistence layer, no migration script. The agent's `CLAUDE.md` is the state model: it reacts 👀 on receipt, updates to 👏/💔/✍/etc. on completion, and that's it. Simpler is better for personal use.

**Channel-agnostic interface, Telegram-specific implementation.** The `Channel.reactToMessage?()` hook (added to `src/types.ts`) means any channel with a reactions API can plug in. WhatsApp's existing skill/reactions branch could be adapted to implement the same hook, and then a single unified MCP tool works across both channels without further changes.

## Changes (6 files)

| File | What |
|---|---|
| `src/types.ts` | `Channel` interface gains optional `reactToMessage?(jid, messageId, emoji)` |
| `src/ipc.ts` | `IpcDeps.reactToMessage?` + new `type: 'react'` branch in `processIpcFiles` with sender-group authorization and graceful drop when no channel supports it |
| `src/channels/telegram.ts` | `private botId`, `bot.on('message_reaction')` handler (filters bot's own reactions, delivers newly-added emoji as synthetic user messages), `reactToMessage()` public method wrapping `bot.api.setMessageReaction`, `allowed_updates: [..., 'message_reaction']` in `bot.start()` |
| `container/agent-runner/src/ipc-mcp-stdio.ts` | new `react_to_message` MCP tool — writes IPC file with `type: 'react'`, tool description documents both directions + the Telegram whitelist caveat |
| `src/index.ts` | `reactToMessage` closure in `startIpcWatcher` that finds the owning channel via `findChannel(jid)` and calls `channel.reactToMessage`, with warn logs for missing channel or missing hook |
| `.claude/skills/add-telegram-reactions/SKILL.md` (new) | Full operational skill — Phase 1 pre-flight, Phase 2 exact diffs for all 5 code files, Phase 3 verification, Phase 4 command-vocabulary design guidance, Telegram whitelist documented inline |

## Key implementation detail: `allowed_updates`

grammy's default polling set does **NOT** subscribe to `message_reaction` updates — `bot.start()` without `allowed_updates` silently drops reaction events. The `connect()` call explicitly lists:

```ts
allowed_updates: ['message', 'edited_message', 'callback_query', 'message_reaction']
```

Without this, Telegram simply doesn't deliver reaction updates to the bot. This is the single most important thing to get right when enabling reactions on a Telegram bot.

## Telegram Bot API whitelist

Telegram restricts bot reactions to a fixed ~74-emoji whitelist. grammy's types enforce it at compile time (the `emoji` field on `ReactionTypeEmoji` is a literal union). The MCP tool accepts dynamic strings, so the channel layer casts at the API boundary (`emoji as never`) and logs `REACTION_INVALID` failures at warn level — unsupported emoji surface visibly rather than disappearing silently.

The SKILL.md lists the full whitelist inline so users picking a command vocabulary have a reference without needing to consult the Bot API docs.

## Test plan

- [x] `npm run build` — clean on `telegram/main` baseline
- [x] `npm test` — 301/301 pass (no test changes needed — the new code paths are gated on an optional interface method)
- [x] Live verification on macOS 26.3.1 + Apple Container 0.11.0: agent reacts via `react_to_message`, incoming user reactions arrive as `[Reaction: X] on message Y`, `allowed_updates` includes `message_reaction` in the `bot.start()` call (verified via grammy's startup config)

## Related

Fourth contribution to nanoclaw-telegram. Related open PRs:

- qwibitai/nanoclaw#1735 — apple-container fixes
- qwibitai/nanoclaw#1737 — Google Calendar MCP integration
- qwibitai/nanoclaw#1747 — Todoist MCP integration
- qwibitai/nanoclaw-telegram#143 — image-vision port to Telegram

Happy to restructure the PR or adjust the skill doc format if anything conflicts with project conventions. Tested end-to-end in daily use.