### PR TITLE
feat(telegram): inline keyboard buttons with Bot API 9.4 native colors

### DIFF
--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -68,6 +68,141 @@ server.tool(
 );
 
 server.tool(
+  'react_to_message',
+  `Send an emoji reaction to a specific message in the chat. Use as a lightweight status signal or acknowledgment without sending a full text reply.
+
+CHANNEL SUPPORT: currently implemented for Telegram. On channels without reaction support the IPC is silently dropped at the host layer — check channel capabilities before relying on this tool for critical feedback.
+
+TELEGRAM WHITELIST: the Telegram Bot API only accepts reactions from a fixed emoji whitelist (~74 standard reactions). If the emoji is not in the whitelist, the reaction silently fails on the API side and is logged at warn level on the host.
+
+Status signals (when reacting to the user's message — agent → user):
+• 👀 — seen, starting to process
+• ⚡ — working on a long task (browser, research, big ingest)
+• 👏 — done successfully
+• 🤔 — need clarification from the user
+• 🫡 — scheduled / queued for later
+• ✍ — ingested into the wiki
+• 🙏 — repeating / retrying
+• 💔 — failed, could not complete
+• 🙊 — acknowledged silently, no text reply needed
+
+Commands (when the user reacts to the agent's message — these arrive as "[Reaction: X] on message Y" synthetic messages and should be interpreted as shortcut commands):
+• 👍 confirm last pending action    • 👎 reject / cancel
+• ❤ remember / ingest to wiki        • 🤩 repeat last action
+• 🔥 important / pin                  • 👌 mark Todoist task done
+• 🤬 stop / delete                    • 🤔 explain in more detail
+• 🫡 follow-up reminder               • 😴 quiet, no text reply
+
+See the telegram-reactions skill (in the group's skills directory) for full semantics and examples.`,
+  {
+    message_id: z
+      .string()
+      .describe(
+        'The message ID to react to. For incoming user messages, use the id field from the message. For your own previous messages, note the id at send time.',
+      ),
+    emoji: z
+      .string()
+      .describe(
+        'The emoji character to react with. Use one from the whitelist above — other emoji will silently fail.',
+      ),
+  },
+  async (args) => {
+    writeIpcFile(MESSAGES_DIR, {
+      type: 'react',
+      chatJid,
+      messageId: args.message_id,
+      emoji: args.emoji,
+      groupFolder,
+      timestamp: new Date().toISOString(),
+    });
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `Reaction ${args.emoji} queued for message ${args.message_id}.`,
+        },
+      ],
+    };
+  },
+);
+
+server.tool(
+  'send_message_with_buttons',
+  `Send a message with inline keyboard buttons. Buttons appear below the message text as tappable elements.
+
+WHEN TO USE: whenever you present choices to the user — drafts (create/cancel), yes/no confirmations,
+multi-option decisions (wiki/chat/skip), recommendations (do/defer/ignore).
+
+NATIVE COLORS (Bot API 9.4, February 2026) — use \`style\` field:
+• style: "success" — GREEN button (confirm / create / yes / send / ingest)
+• style: "danger"  — RED button   (cancel / delete / no / remove)
+• style: "primary" — BLUE button  (main action, neutral primary choice)
+• no style         — GREY button  (secondary / skip / details / later)
+
+EMOJI PREFIX — always add an emoji too, it works on older clients and reinforces meaning:
+• ✅ success  • ❌ danger  • ✍️ wiki  • 💬 chat  • ⏭ skip  • 🗑 delete  • ℹ️ info
+
+BUTTON LIMITS: max 4 buttons per row, max 4 rows. More = cluttered.
+MAX 1 "success" and 1 "danger" per row — don't stack same color.
+
+CALLBACK DATA: ≤ 64 bytes. Use format \`<action>:<payload>\` when needed (e.g. "task:create", "lint:6").
+Button taps arrive as synthetic messages: \`[Callback: <data>] on message <id>\`
+Treat them like confirmed actions — no need to ask again.`,
+  {
+    text: z.string().describe('Message text (Markdown supported: *bold*, _italic_, `code`)'),
+    buttons: z
+      .array(
+        z.array(
+          z.object({
+            text: z
+              .string()
+              .describe('Button label. Always include emoji prefix (✅ ❌ ✍️ etc.) AND set style for color.'),
+            data: z
+              .string()
+              .max(64)
+              .optional()
+              .describe('Callback data (≤ 64 bytes). Use format "action:payload".'),
+            url: z
+              .string()
+              .url()
+              .optional()
+              .describe('URL to open (alternative to callback data).'),
+            style: z
+              .enum(['success', 'danger', 'primary'])
+              .optional()
+              .describe('Bot API 9.4 native color: success=green, danger=red, primary=blue. Omit for default grey.'),
+          }),
+        ),
+      )
+      .describe('2D array of buttons: outer = rows, inner = buttons in each row. Max 4×4.'),
+    sender: z
+      .string()
+      .optional()
+      .describe('Your role/identity name (e.g. "Mila"). When set, messages appear from a dedicated bot in Telegram.'),
+  },
+  async (args) => {
+    writeIpcFile(MESSAGES_DIR, {
+      type: 'message_with_buttons',
+      chatJid,
+      text: args.text,
+      buttons: args.buttons,
+      sender: args.sender || undefined,
+      groupFolder,
+      timestamp: new Date().toISOString(),
+    });
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: 'Message with buttons sent.',
+        },
+      ],
+    };
+  },
+);
+
+server.tool(
   'schedule_task',
   `Schedule a recurring or one-time task. The task will run as a full agent with access to all tools. Returns the task ID for future reference. To modify an existing task, use update_task instead.
 

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -10,6 +10,7 @@ import { resolveGroupFolderPath } from '../group-folder.js';
 import { logger } from '../logger.js';
 import { registerChannel, ChannelOpts } from './registry.js';
 import {
+  InlineButton,
   Channel,
   OnChatMetadata,
   OnInboundMessage,
@@ -336,6 +337,126 @@ export class TelegramChannel implements Channel {
     this.bot.on('message:location', (ctx) => storeMedia(ctx, '[Location]'));
     this.bot.on('message:contact', (ctx) => storeMedia(ctx, '[Contact]'));
 
+    // Two-way emoji reactions channel — see
+    // groups/<group>/skills/telegram-reactions/SKILL.md for the full spec.
+    // Delivers newly added emoji reactions from registered chats as
+    // synthetic messages `[Reaction: X] on message Y` that the agent
+    // interprets as commands. Bot's own reactions are filtered out so
+    // Mila doesn't echo her own status signals as incoming commands.
+    this.bot.on('message_reaction', async (ctx) => {
+      const chatJid = `tg:${ctx.chat.id}`;
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) return;
+
+      const reaction = ctx.messageReaction;
+      if (!reaction) return;
+
+      // Filter out the bot's own reactions — Telegram sometimes echoes them
+      // back as message_reaction updates (depending on polling config).
+      const user = reaction.user;
+      const reactorId = user?.id;
+      if (this.botId != null && reactorId === this.botId) return;
+
+      const timestamp = new Date(reaction.date * 1000).toISOString();
+      const senderName = user
+        ? user.first_name || user.username || user.id.toString()
+        : 'Unknown';
+      const sender = reactorId != null ? reactorId.toString() : '';
+
+      // Only deliver NEWLY added emojis (set difference new - old). Removed
+      // reactions are ignored — we don't model un-reactions as commands.
+      // grammy narrows `r.emoji` to the allowed-whitelist literal union when
+      // `r.type === 'emoji'`, which widens to `string` on assignment.
+      const oldEmojis = new Set<string>();
+      for (const r of reaction.old_reaction || []) {
+        if (r.type === 'emoji') oldEmojis.add(r.emoji);
+      }
+      const addedEmojis: string[] = [];
+      for (const r of reaction.new_reaction || []) {
+        if (r.type === 'emoji' && !oldEmojis.has(r.emoji)) {
+          addedEmojis.push(r.emoji);
+        }
+      }
+
+      if (addedEmojis.length === 0) return;
+
+      const isGroup =
+        ctx.chat.type === 'group' || ctx.chat.type === 'supergroup';
+      this.opts.onChatMetadata(
+        chatJid,
+        timestamp,
+        undefined,
+        'telegram',
+        isGroup,
+      );
+
+      for (const emoji of addedEmojis) {
+        this.opts.onMessage(chatJid, {
+          id: `reaction-${reaction.message_id}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+          chat_jid: chatJid,
+          sender,
+          sender_name: senderName,
+          content: `[Reaction: ${emoji}] on message ${reaction.message_id}`,
+          timestamp,
+          is_from_me: false,
+        });
+      }
+    });
+
+    // Inline button callback queries — see inline-buttons skill for usage.
+    // Delivers button presses as synthetic `[Callback: <data>] on message <id>`
+    // messages. Auto-answers the callback query immediately (removes loading
+    // indicator) so the button tap feels instant.
+    this.bot.on('callback_query:data', async (ctx) => {
+      const chatJid = `tg:${ctx.chat?.id ?? ctx.callbackQuery.message?.chat.id}`;
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) {
+        await ctx.answerCallbackQuery().catch(() => {}); // answer even for unregistered
+        return;
+      }
+
+      // Answer immediately to remove the loading spinner on the button
+      await ctx.answerCallbackQuery().catch((err) => {
+        logger.debug({ err }, 'Failed to answer callback query');
+      });
+
+      const data = ctx.callbackQuery.data ?? '';
+      const origMsgId =
+        ctx.callbackQuery.message?.message_id?.toString() ?? '';
+      const timestamp = new Date().toISOString();
+      const senderName =
+        ctx.from?.first_name ||
+        ctx.from?.username ||
+        ctx.from?.id.toString() ||
+        'Unknown';
+      const sender = ctx.from?.id.toString() ?? '';
+
+      const isGroup =
+        ctx.chat?.type === 'group' || ctx.chat?.type === 'supergroup';
+      this.opts.onChatMetadata(
+        chatJid,
+        timestamp,
+        undefined,
+        'telegram',
+        isGroup,
+      );
+
+      this.opts.onMessage(chatJid, {
+        id: `callback-${ctx.callbackQuery.id}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+        chat_jid: chatJid,
+        sender,
+        sender_name: senderName,
+        content: `[Callback: ${data}] on message ${origMsgId}`,
+        timestamp,
+        is_from_me: false,
+      });
+
+      logger.info(
+        { chatJid, data, origMsgId, sender: senderName },
+        'Telegram callback query delivered',
+      );
+    });
+
     // Handle errors gracefully
     this.bot.catch((err) => {
       logger.error({ err: err.message }, 'Telegram bot error');
@@ -357,6 +478,105 @@ export class TelegramChannel implements Channel {
         },
       });
     });
+  }
+
+  /**
+   * Send an emoji reaction to a specific message. Used by the
+   * `react_to_message` MCP tool so the agent can signal status (👀 / ⚡ /
+   * 👏 / 💔 etc.) without a full text reply. Telegram only allows a fixed
+   * whitelist of emoji for reactions; unsupported emoji will produce a
+   * `REACTION_INVALID` error which we log at warn level so the set can be
+   * tuned over time.
+   */
+  async reactToMessage(
+    jid: string,
+    messageId: string,
+    emoji: string,
+  ): Promise<void> {
+    if (!this.bot) {
+      logger.warn('Telegram bot not initialized (reactToMessage)');
+      return;
+    }
+    try {
+      const numericChatId = Number(jid.replace(/^tg:/, ''));
+      const numericMsgId = Number.parseInt(messageId, 10);
+      if (Number.isNaN(numericChatId) || Number.isNaN(numericMsgId)) {
+        logger.warn(
+          { jid, messageId },
+          'reactToMessage: invalid chat or message id',
+        );
+        return;
+      }
+      await this.bot.api.setMessageReaction(numericChatId, numericMsgId, [
+        { type: 'emoji', emoji: emoji as never },
+      ]);
+      logger.info(
+        { jid, messageId, emoji },
+        'Telegram reaction sent',
+      );
+    } catch (err) {
+      logger.warn(
+        { jid, messageId, emoji, err },
+        'Failed to send Telegram reaction (likely REACTION_INVALID — emoji not in Bot API whitelist)',
+      );
+    }
+  }
+
+  /**
+   * Send a message with an inline keyboard. Callback presses are delivered as
+   * synthetic `[Callback: <data>] on message <id>` messages via the
+   * callback_query handler below.
+   */
+  async sendMessageWithButtons(
+    jid: string,
+    text: string,
+    buttons: InlineButton[][],
+  ): Promise<void> {
+    if (!this.bot) {
+      logger.warn('Telegram bot not initialized (sendMessageWithButtons)');
+      return;
+    }
+    try {
+      const numericId = jid.replace(/^tg:/, '');
+      const inline_keyboard = buttons.map((row) =>
+        row.map((btn) => {
+          if (btn.url) {
+            return { text: btn.text, url: btn.url };
+          }
+          // Bot API 9.4: style and icon_custom_emoji_id are not yet in grammy
+          // types — pass as `unknown` to bypass type checking.
+          const buttonObj: Record<string, unknown> = {
+            text: btn.text,
+            callback_data: btn.data ?? '',
+          };
+          if (btn.style) buttonObj.style = btn.style;
+          if (btn.icon_custom_emoji_id) buttonObj.icon_custom_emoji_id = btn.icon_custom_emoji_id;
+          return buttonObj;
+        }),
+      );
+      await this.bot.api.sendMessage(numericId, text, {
+        parse_mode: 'Markdown',
+        reply_markup: { inline_keyboard } as never,
+      });
+      logger.info({ jid, rows: buttons.length }, 'Telegram message with buttons sent');
+    } catch (err) {
+      // Fallback: send as plain text without buttons
+      logger.warn({ jid, err }, 'Failed to send Telegram message with buttons, falling back');
+      try {
+        const numericId = jid.replace(/^tg:/, '');
+        const fallbackText =
+          text +
+          '\n\n' +
+          buttons
+            .flat()
+            .filter((b) => b.data)
+            .map((b) => `• ${b.text} → \`${b.data}\``)
+            .join('\n');
+        await this.bot.api.sendMessage(numericId, fallbackText);
+      } catch (fallbackErr) {
+        logger.error({ jid, fallbackErr }, 'Failed to send Telegram fallback message');
+      }
+    }
   }
 
   async sendMessage(

--- a/src/index.ts
+++ b/src/index.ts
@@ -717,6 +717,39 @@ async function main(): Promise<void> {
       if (!channel) throw new Error(`No channel for JID: ${jid}`);
       return channel.sendMessage(jid, text);
     },
+    reactToMessage: async (jid, messageId, emoji) => {
+      const channel = findChannel(channels, jid);
+      if (!channel) {
+        logger.warn(
+          { jid, messageId, emoji },
+          'reactToMessage: no channel owns JID',
+        );
+        return;
+      }
+      if (!channel.reactToMessage) {
+        logger.warn(
+          { jid, channel: channel.name, messageId, emoji },
+          'reactToMessage: channel does not support reactions, dropping',
+        );
+        return;
+      }
+      await channel.reactToMessage(jid, messageId, emoji);
+    },
+    sendMessageWithButtons: async (jid, text, buttons) => {
+      const channel = findChannel(channels, jid);
+      if (!channel) {
+        logger.warn({ jid }, 'sendMessageWithButtons: no channel owns JID');
+        return;
+      }
+      if (!channel.sendMessageWithButtons) {
+        logger.warn(
+          { jid, channel: channel.name },
+          'sendMessageWithButtons: channel does not support inline buttons, dropping',
+        );
+        return;
+      }
+      await channel.sendMessageWithButtons(jid, text, buttons);
+    },
     registeredGroups: () => registeredGroups,
     registerGroup,
     syncGroups: async (force: boolean) => {

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -23,6 +23,29 @@ export interface IpcDeps {
     registeredJids: Set<string>,
   ) => void;
   onTasksChanged: () => void;
+  // Optional: send an emoji reaction to a message. Only populated when at
+  // least one connected channel implements the Channel.reactToMessage hook
+  // (e.g. Telegram). If missing, `type: 'react'` IPC files are silently
+  // dropped with a warn log — the agent still thinks it succeeded at the
+  // MCP boundary but no reaction ever reaches the chat.
+  reactToMessage?: (
+    jid: string,
+    messageId: string,
+    emoji: string,
+  ) => Promise<void>;
+  // Optional: send a message with inline keyboard buttons. Only populated
+  // when the connected channel implements Channel.sendMessageWithButtons.
+  sendMessageWithButtons?: (
+    jid: string,
+    text: string,
+    buttons: Array<Array<{
+      text: string;
+      data?: string;
+      url?: string;
+      style?: 'success' | 'danger' | 'primary'; // Bot API 9.4
+      icon_custom_emoji_id?: string;             // Bot API 9.4
+    }>>,
+  ) => Promise<void>;
 }
 
 let ipcWatcherRunning = false;
@@ -90,6 +113,79 @@ export function startIpcWatcher(deps: IpcDeps): void {
                   logger.warn(
                     { chatJid: data.chatJid, sourceGroup },
                     'Unauthorized IPC message attempt blocked',
+                  );
+                }
+              } else if (
+                data.type === 'react' &&
+                data.chatJid &&
+                data.messageId &&
+                data.emoji
+              ) {
+                // Authorization: same rules as IPC message — only the
+                // owning group (or the main group) can emit reactions
+                // into this chat.
+                const targetGroup = registeredGroups[data.chatJid];
+                const authorized =
+                  isMain ||
+                  (targetGroup && targetGroup.folder === sourceGroup);
+                if (!authorized) {
+                  logger.warn(
+                    { chatJid: data.chatJid, sourceGroup },
+                    'Unauthorized IPC reaction attempt blocked',
+                  );
+                } else if (!deps.reactToMessage) {
+                  logger.warn(
+                    {
+                      chatJid: data.chatJid,
+                      sourceGroup,
+                      emoji: data.emoji,
+                    },
+                    'IPC reaction dropped — no channel supports reactToMessage',
+                  );
+                } else {
+                  await deps.reactToMessage(
+                    data.chatJid,
+                    data.messageId,
+                    data.emoji,
+                  );
+                  logger.info(
+                    {
+                      chatJid: data.chatJid,
+                      sourceGroup,
+                      messageId: data.messageId,
+                      emoji: data.emoji,
+                    },
+                    'IPC reaction sent',
+                  );
+                }
+              } else if (
+                data.type === 'message_with_buttons' &&
+                data.chatJid &&
+                data.text &&
+                Array.isArray(data.buttons)
+              ) {
+                const targetGroup = registeredGroups[data.chatJid];
+                const authorized =
+                  isMain || (targetGroup && targetGroup.folder === sourceGroup);
+                if (!authorized) {
+                  logger.warn(
+                    { chatJid: data.chatJid, sourceGroup },
+                    'Unauthorized IPC message_with_buttons attempt blocked',
+                  );
+                } else if (!deps.sendMessageWithButtons) {
+                  logger.warn(
+                    { chatJid: data.chatJid, sourceGroup },
+                    'IPC message_with_buttons dropped — channel does not support inline buttons',
+                  );
+                } else {
+                  await deps.sendMessageWithButtons(
+                    data.chatJid,
+                    data.text,
+                    data.buttons,
+                  );
+                  logger.info(
+                    { chatJid: data.chatJid, sourceGroup, rows: data.buttons.length },
+                    'IPC message with buttons sent',
                   );
                 }
               }

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,36 @@ export interface TaskRunLog {
   error: string | null;
 }
 
+/**
+ * A single button in an inline keyboard row.
+ * Either `data` (callback) or `url` must be set.
+ *
+ * Bot API 9.4 (February 2026): `style` sets native button color in Telegram UI.
+ * Always include an emoji prefix in `text` as well — it works on older clients.
+ */
+export interface InlineButton {
+  /** Displayed label — always include an emoji prefix for visual meaning */
+  text: string;
+  /** Callback data (≤ 64 bytes). Delivered as `[Callback: <data>] on message <id>`. */
+  data?: string;
+  /** URL to open when button is tapped (alternative to callback). */
+  url?: string;
+  /**
+   * Bot API 9.4 — native button color in Telegram.
+   * "success" = green (confirm/yes/create)
+   * "danger"  = red   (cancel/delete/no)
+   * "primary" = blue  (main action, neutral primary choice)
+   * Omit for default grey (secondary/skip/info buttons).
+   */
+  style?: 'success' | 'danger' | 'primary';
+  /**
+   * Bot API 9.4 — custom emoji icon shown before button text.
+   * Use the emoji's custom_emoji_id from Telegram sticker set.
+   * Optional enhancement; not required.
+   */
+  icon_custom_emoji_id?: string;
+}
+
 // --- Channel abstraction ---
 
 export interface Channel {
@@ -95,6 +125,19 @@ export interface Channel {
   setTyping?(jid: string, isTyping: boolean): Promise<void>;
   // Optional: sync group/chat names from the platform.
   syncGroups?(force: boolean): Promise<void>;
+  // Optional: send an emoji reaction to a specific message. Used by the
+  // `react_to_message` MCP tool so the agent can signal status or command
+  // acknowledgments without a full text reply. See the telegram-reactions
+  // skill doc in the relevant group for usage semantics.
+  reactToMessage?(jid: string, messageId: string, emoji: string): Promise<void>;
+  // Optional: send a message with an inline keyboard. Callback presses are
+  // delivered as synthetic `[Callback: <data>] on message <id>` messages.
+  // See the inline-buttons skill doc for usage semantics and emoji color guide.
+  sendMessageWithButtons?(
+    jid: string,
+    text: string,
+    buttons: InlineButton[][],
+  ): Promise<void>;
 }
 
 // Callback type that channels use to deliver inbound messages


### PR DESCRIPTION
## Summary
- Add `send_message_with_buttons` MCP tool so agents can present choices
  as tappable inline buttons instead of plain text lists
- Button presses arrive as synthetic `[Callback: <data>] on message <id>`
  messages — same delivery pattern as emoji reactions
- Supports Bot API 9.4 `style` field (success/danger/primary) for native
  button colors, with emoji prefixes as fallback for older clients
- Includes full IPC pipeline with authorization checks and text fallback
  when buttons fail

## Changes (5 files)
| File | What |
|------|------|
| `src/types.ts` | `InlineButton` type + `Channel.sendMessageWithButtons` |
| `src/channels/telegram.ts` | Method implementation + `callback_query:data` handler |
| `src/ipc.ts` | `IpcDeps` extension + `message_with_buttons` handler |
| `container/agent-runner/src/ipc-mcp-stdio.ts` | MCP tool definition |
| `src/index.ts` | Wiring in `startIpcWatcher` |

## Design decisions
- **Callback format** matches reaction pattern: `[Callback: data] on message id`
  — agent treats it as confirmed action, no re-confirmation needed
- **Fallback**: if inline keyboard fails (parse_mode conflict), sends plain
  text with button labels and callback data
- **Authorization**: same rules as IPC messages — only owning group or main
  can send buttons to a chat
- **Limits**: max 4×4 buttons, callback_data ≤ 64 bytes (Telegram API limit)

## Test plan
- [ ] Send message with 2-button row (confirm/cancel) — buttons render
- [ ] Tap a button — `[Callback: <data>] on message <id>` delivered to agent
- [ ] Verify `answerCallbackQuery` removes loading spinner instantly
- [ ] Test fallback: send malformed Markdown with buttons — falls back to text
- [ ] Non-Telegram channels: `sendMessageWithButtons` gracefully drops with warn log

🤖 Generated with [Claude Code](https://claude.com/claude-code)