### PR TITLE
feat(telegram): implement sendFile for photo and document delivery

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import https from 'https';
 import path from 'path';
 
-import { Api, Bot } from 'grammy';
+import { Api, Bot, InputFile } from 'grammy';
 
 import { ASSISTANT_NAME, TRIGGER_PATTERN } from '../config.js';
 import { readEnvFile } from '../env.js';
@@ -357,6 +357,39 @@ export class TelegramChannel implements Channel {
         },
       });
     });
+  }
+
+  async sendFile(
+    jid: string,
+    filePath: string,
+    caption?: string,
+  ): Promise<void> {
+    if (!this.bot) {
+      logger.warn('Telegram bot not initialized (sendFile)');
+      return;
+    }
+    try {
+      const numericId = jid.replace(/^tg:/, '');
+      const ext = path.extname(filePath).toLowerCase();
+      const isPhoto = ['.jpg', '.jpeg', '.png', '.webp'].includes(ext);
+
+      if (isPhoto) {
+        await this.bot.api.sendPhoto(
+          numericId,
+          new InputFile(filePath),
+          caption ? { caption, parse_mode: 'Markdown' } : undefined,
+        );
+      } else {
+        await this.bot.api.sendDocument(
+          numericId,
+          new InputFile(filePath),
+          caption ? { caption, parse_mode: 'Markdown' } : undefined,
+        );
+      }
+      logger.info({ jid, filePath, isPhoto }, 'Telegram file sent');
+    } catch (err) {
+      logger.error({ jid, filePath, err }, 'Failed to send Telegram file');
+    }
   }
 
   async sendMessage(


### PR DESCRIPTION
## Summary

- Add `sendFile()` method to TelegramChannel for sending files to chat
- Photos (.jpg, .jpeg, .png, .webp) sent via `sendPhoto` for inline display
- Other file types sent via `sendDocument` as attachments
- Optional Markdown caption support
- Imports `InputFile` from grammy for local file uploads

## Dependencies

- Requires core `send_file` MCP tool and IPC handler: qwibitai/nanoclaw#1757

## Test plan

- [x] Build passes
- [x] Photos delivered as inline images in Telegram
- [x] Documents delivered as file attachments
- [x] Caption with Markdown formatting works
- [x] Missing/invalid file path logged as error without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)